### PR TITLE
perf: disable mangle and remove entities package for decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
   "dependencies": {
     "@jsamr/counter-style": "^2.0.2",
     "@jsamr/react-native-li": "^2.3.1",
-    "entities": "^4.4.0",
     "marked": "^4.0.18",
     "react-native-fit-image": "^1.5.5"
   }

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -20,7 +20,10 @@ const Markdown = ({
     const parser = new Parser({
       styles,
     });
-    const tokens = marked.lexer(value);
+    const tokens = marked.lexer(value, {
+      mangle: false,
+      gfm: true,
+    });
 
     return parser.parse(tokens);
   }, [value, styles]);

--- a/src/lib/Parser.tsx
+++ b/src/lib/Parser.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import type { TextStyle, ViewStyle, ImageStyle } from 'react-native';
 import type { marked } from 'marked';
-import { decode } from 'entities';
 import Renderer from './Renderer';
 import type { MarkedStyles } from '../theme/types';
 import type { ParserOptions } from './types';
@@ -172,7 +171,7 @@ class Parser {
         }
         case 'text':
         case 'html': {
-          return this.renderer.getTextNode(decode(token.raw), {
+          return this.renderer.getTextNode(token.raw, {
             ...this.styles.text,
             ...styles,
           });


### PR DESCRIPTION
By disabling mangle from marked.js we don't need to do entities decode. This will improve the performance and reduce the package size.

As a side-effect we need to enable github flavoured markdown to support some additional emphasis.