### PR TITLE
Make parser overrideable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import Markdown from "./lib/Markdown";
+export * from "./lib/Renderer";
 
 export default Markdown;

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -11,6 +11,7 @@ const Markdown = ({
 	theme,
 	baseUrl,
 	styles: userStyles,
+	parser: customParser,
 }: MarkdownProps) => {
 	const colorScheme = useColorScheme();
 	const styles = useMemo(
@@ -21,6 +22,9 @@ const Markdown = ({
 	const rnElements = useMemo(() => {
 		const parser = new Parser({ styles, baseUrl });
 		const tokens = marked.lexer(value, { mangle: false, gfm: true });
+		if (customParser) {
+			return customParser(parser).parse(tokens);
+		}
 		return parser.parse(tokens);
 	}, [value, styles, baseUrl]);
 

--- a/src/lib/Parser.tsx
+++ b/src/lib/Parser.tsx
@@ -3,10 +3,10 @@ import type { TextStyle, ViewStyle, ImageStyle } from "react-native";
 import type { marked } from "marked";
 import Renderer from "./Renderer";
 import type { MarkedStyles } from "../theme/types";
-import type { ParserOptions } from "./types";
+import type { IParser, ParserOptions } from "./types";
 import { getValidURL } from "./../utils/url";
 
-class Parser {
+class Parser implements IParser {
 	private renderer;
 	private styles: MarkedStyles;
 	private headingStylesMap: Record<number, TextStyle | undefined>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
-import type { FlatListProps } from "react-native";
+import type {
+	FlatListProps,
+	ImageStyle,
+	TextStyle,
+	ViewStyle,
+} from "react-native";
 import type { MarkedStyles, UserTheme } from "./../theme/types";
+import type { marked } from "marked";
 
 export interface ParserOptions {
 	styles?: MarkedStyles;
@@ -14,4 +20,17 @@ export interface MarkdownProps extends ParserOptions {
 		"data" | "renderItem" | "horizontal"
 	>;
 	theme?: UserTheme;
+	parser?: CustomParser;
 }
+
+export interface IParser {
+	parse: (tokens: marked.Token[]) => ReactNode[];
+	parseInline: (
+		tokens: marked.Token[],
+		styles?: ViewStyle | TextStyle | ImageStyle,
+	) => ReactNode[];
+}
+
+export type CustomParser = (baseParser: IParser) => {
+	parse: (tokens: marked.Token[]) => ReactNode[];
+};


### PR DESCRIPTION
Hi @gmsgowtham, here's a way to override the parser -- I needed something to customize the code blocks. It can be used like so:

```typescript
const customParser = (baseParser: any) => ({
  parse: (tokens) => {
    const nodes: ReactNode[] = []
    tokens.forEach((token) => {
      if (token.type === 'code') {
        nodes.push(<CodeBlock content={token.text} />)
        return true
      }
      nodes.push(...baseParser.parse([token]))
    })
    return nodes
  },
})
  
// ...

<Markdown
  parser={customParser}
  ...
  />
```