### PR TITLE
Revert "fix(deps): update dependency marked to v5.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "dependencies": {
     "@jsamr/counter-style": "2.0.2",
     "@jsamr/react-native-li": "2.3.1",
-    "marked": "5.1.0",
+    "marked": "5.0.5",
     "react-native-svg": "13.9.0",
     "react-native-table-component": "1.2.2",
     "svg-parser": "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,10 +8200,10 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
-marked@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-5.1.0.tgz#cf51f03ba04dfb3469774029fd0106d258658767"
-  integrity sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==
+marked@5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-5.0.5.tgz#1c7bd284d7d29d7d75d6241b26e5d5bf3b558a12"
+  integrity sha512-auTmKJTBwZM/GLVFOhmkY7pL8v/0DxiDaXRC2kEyajcNJ0XXn9NphLD0106dbWrbPwcyD4Y0Dus16OkCzUMkfg==
 
 mathjs@^11.5.0:
   version "11.6.0"


### PR DESCRIPTION
Reverts gmsgowtham/react-native-marked#381

Bug in hermes throws regex escape errors

Ref: https://github.com/markedjs/marked/issues/2843, https://github.com/facebook/hermes/issues/1027