### PR TITLE
fix: allow URLs with non-http schemes in links

### DIFF
--- a/src/utils/__tests__/url.spec.ts
+++ b/src/utils/__tests__/url.spec.ts
@@ -29,4 +29,18 @@ describe("getValidURL", () => {
 	it("empty prefix", () => {
 		expect(getValidURL("", "path")).toBe("/path");
 	});
+	it("ignores prefix value for non-http URLs", () => {
+		expect(getValidURL("", "mailto:example.com")).toBe("mailto:example.com");
+		expect(getValidURL("https://www.example.com", "mailto:example.com")).toBe(
+			"mailto:example.com",
+		);
+		expect(getValidURL("", "tel:0123456789")).toBe("tel:0123456789");
+		expect(getValidURL("https://www.example.com", "tel:0123456789")).toBe(
+			"tel:0123456789",
+		);
+		expect(getValidURL("", "slack://open")).toBe("slack://open");
+		expect(getValidURL("https://www.example.com", "slack://open")).toBe(
+			"slack://open",
+		);
+	});
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -5,8 +5,10 @@ export const getValidURL = (prefix: string, path: string) => {
 		_prefix = _prefix.slice(0, -1);
 	}
 
-	// path is valid url
-	if (path.startsWith("https") || path.startsWith("http")) {
+	// consider path a valid url if it starts with a scheme name followed by a semicolon
+	// i.e. https://example.com, mailto:person@example.com, tel:1234567, slack://open
+	const urlPattern = /^[a-z]+:/i;
+	if (urlPattern.test(path)) {
 		return path;
 	}
 


### PR DESCRIPTION
Thanks for your work on this library!

In my app I needed to also allow links that do not point to webpages, such as:
- `mailto:user@example.com` to start the mail application
- `tel:012345` to start the phone app
-  or other apps that may be installed such as `slack://open`

This library currently prefixes such links with "/" because they do not start with http/https and therefore it thinks they are relative URLs. So for example `mailto:` became `/mailto:`, making the link incorrect. This pull request should fix that, allowing non-http URLs to work.