### PR TITLE
feat: add depth to heading renderer

### DIFF
--- a/src/lib/Parser.tsx
+++ b/src/lib/Parser.tsx
@@ -57,7 +57,7 @@ class Parser {
 			case "heading": {
 				const styles = this.headingStylesMap[token.depth];
 				const children = this._parse(token.tokens, styles);
-				return this.renderer.heading(children, styles);
+				return this.renderer.heading(children, styles, token.depth);
 			}
 			case "code": {
 				return this.renderer.code(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,7 +29,11 @@ export type TableColAlignment = "center" | "left" | "right" | null;
 export interface RendererInterface {
 	paragraph(children: ReactNode[], styles?: ViewStyle): ReactNode;
 	blockquote(children: ReactNode[], styles?: ViewStyle): ReactNode;
-	heading(text: string | ReactNode[], styles?: TextStyle): ReactNode;
+	heading(
+		text: string | ReactNode[],
+		styles?: TextStyle,
+		depth?: number,
+	): ReactNode;
 	code(
 		text: string,
 		language?: string,


### PR DESCRIPTION
Hi, Thanks for this great library. 🙇🏻‍♂️

I'd like to use depth on my custom renderer. 
However, there's nowhere to know which `h` depth. 

Can it be fixed like this?  

 