### PR TITLE
fix: make react-native-svg a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,172 +1,180 @@
 {
-	"name": "react-native-marked",
-	"version": "6.0.6",
-	"description": "Markdown renderer for React Native powered by marked.js",
-	"main": "dist/commonjs/index",
-	"module": "dist/module/index",
-	"types": "dist/typescript/index.d.ts",
-	"react-native": "src/index",
-	"source": "src/index",
-	"files": [
-		"src",
-		"dist",
-		"android",
-		"ios",
-		"cpp",
-		"react-native-marked.podspec",
-		"!dist/typescript/example",
-		"!android/build",
-		"!ios/build",
-		"!**/__tests__",
-		"!**/__fixtures__",
-		"!**/__mocks__",
-		"!**/__perf__"
-	],
-	"scripts": {
-		"typescript": "tsc --noEmit",
-		"lint": "biome check ./",
-		"format": "biome format ./ --write",
-		"build": "bob build",
-		"prepare": "yarn build",
-		"release": "yarn build && release-it",
-		"release:rc": "yarn build && release-it --preRelease=rc",
-		"release:exclude-pre": "yarn build && release-it --git.tagExclude='*[-]*'",
-		"test": "jest --passWithNoTests",
-		"test:updateSnapshot": "jest --updateSnapshot",
-		"reassure": "reassure"
-	},
-	"keywords": ["react-native", "markdown", "react-native markdown"],
-	"repository": "https://github.com/gmsgowtham/react-native-marked",
-	"author": "Gowtham G <webappsbygowtham@gmail.com> (https://github.com/gmsgowtham)",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/gmsgowtham/react-native-marked/issues"
-	},
-	"homepage": "https://github.com/gmsgowtham/react-native-marked#readme",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/"
-	},
-	"devDependencies": {
-		"@babel/core": "7.26.0",
-		"@babel/helper-explode-assignable-expression": "7.18.6",
-		"@babel/preset-env": "7.26.0",
-		"@biomejs/biome": "1.9.4",
-		"@commitlint/config-conventional": "19.5.0",
-		"@evilmartians/lefthook": "1.8.2",
-		"@release-it/conventional-changelog": "9.0.4",
-		"@testing-library/jest-native": "5.4.3",
-		"@testing-library/react-native": "12.9.0",
-		"@types/jest": "29.5.14",
-		"@types/marked": "5.0.0",
-		"@types/node": "22.10.5",
-		"@types/react": "18.3.12",
-		"@types/react-native": "0.72.6",
-		"@types/react-native-table-component": "1.2.8",
-		"@types/svg-parser": "^2.0.3",
-		"commitlint": "19.5.0",
-		"danger": "12.3.3",
-		"husky": "9.1.6",
-		"jest": "29.7.0",
-		"jest-environment-jsdom": "29.7.0",
-		"metro-react-native-babel-preset": "0.77.0",
-		"pod-install": "0.3.2",
-		"postinstall-postinstall": "2.1.0",
-		"react": "18.3.1",
-		"react-native": "0.72.6",
-		"react-native-builder-bob": "0.32.1",
-		"react-test-renderer": "18.3.1",
-		"reassure": "1.3.1",
-		"release-it": "17.10.0",
-		"typescript": "5.7.2"
-	},
-	"peerDependencies": {
-		"react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-		"react-native": ">=0.60.0",
-		"react-native-svg": ">=12.3.0"
-	},
-	"jest": {
-		"preset": "react-native",
-		"testEnvironment": "jsdom",
-		"modulePathIgnorePatterns": [
-			"<rootDir>/examples/*/node_modules",
-			"<rootDir>/dist/"
-		],
-		"setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"],
-		"transformIgnorePatterns": [
-			"node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|react-native-table-component)"
-		]
-	},
-	"commitlint": {
-		"extends": ["@commitlint/config-conventional"],
-		"rules": {
-			"type-enum": [
-				2,
-				"always",
-				[
-					"build",
-					"chore",
-					"ci",
-					"docs",
-					"feat",
-					"fix",
-					"perf",
-					"refactor",
-					"revert",
-					"style",
-					"test",
-					"todo",
-					"bump"
-				]
-			]
-		}
-	},
-	"release-it": {
-		"git": {
-			"commitMessage": "chore: release ${version}",
-			"tagName": "v${version}"
-		},
-		"npm": {
-			"publish": true
-		},
-		"github": {
-			"release": true,
-			"web": true
-		},
-		"plugins": {
-			"@release-it/conventional-changelog": {
-				"preset": "angular",
-				"ignoreRecommendedBump": true
-			}
-		}
-	},
-	"react-native-builder-bob": {
-		"source": "src",
-		"output": "dist",
-		"targets": [
-			"commonjs",
-			"module",
-			[
-				"typescript",
-				{
-					"project": "tsconfig.json"
-				}
-			]
-		]
-	},
-	"dependencies": {
-		"@jsamr/counter-style": "2.0.2",
-		"@jsamr/react-native-li": "2.3.1",
-		"html-entities": "2.5.2",
-		"marked": "5.0.5",
-		"react-native-svg": "15.10.1",
-		"react-native-table-component": "1.2.2",
-		"svg-parser": "2.0.4"
-	},
-	"engines": {
-		"node": ">=18"
-	},
-	"resolutions": {
-		"@types/react": "18.3.12",
-		"@types/react-native": "0.72.6"
-	}
+  "name": "react-native-marked",
+  "version": "6.0.6",
+  "description": "Markdown renderer for React Native powered by marked.js",
+  "main": "dist/commonjs/index",
+  "module": "dist/module/index",
+  "types": "dist/typescript/index.d.ts",
+  "react-native": "src/index",
+  "source": "src/index",
+  "files": [
+    "src",
+    "dist",
+    "android",
+    "ios",
+    "cpp",
+    "react-native-marked.podspec",
+    "!dist/typescript/example",
+    "!android/build",
+    "!ios/build",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/__perf__"
+  ],
+  "scripts": {
+    "typescript": "tsc --noEmit",
+    "lint": "biome check ./",
+    "format": "biome format ./ --write",
+    "build": "bob build",
+    "prepare": "yarn build",
+    "release": "yarn build && release-it",
+    "release:rc": "yarn build && release-it --preRelease=rc",
+    "release:exclude-pre": "yarn build && release-it --git.tagExclude='*[-]*'",
+    "test": "jest --passWithNoTests",
+    "test:updateSnapshot": "jest --updateSnapshot",
+    "reassure": "reassure"
+  },
+  "keywords": [
+    "react-native",
+    "markdown",
+    "react-native markdown"
+  ],
+  "repository": "https://github.com/gmsgowtham/react-native-marked",
+  "author": "Gowtham G <webappsbygowtham@gmail.com> (https://github.com/gmsgowtham)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gmsgowtham/react-native-marked/issues"
+  },
+  "homepage": "https://github.com/gmsgowtham/react-native-marked#readme",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "@babel/core": "7.26.0",
+    "@babel/helper-explode-assignable-expression": "7.18.6",
+    "@babel/preset-env": "7.26.0",
+    "@biomejs/biome": "1.9.4",
+    "@commitlint/config-conventional": "19.5.0",
+    "@evilmartians/lefthook": "1.8.2",
+    "@release-it/conventional-changelog": "9.0.4",
+    "@testing-library/jest-native": "5.4.3",
+    "@testing-library/react-native": "12.9.0",
+    "@types/jest": "29.5.14",
+    "@types/marked": "5.0.0",
+    "@types/node": "22.10.5",
+    "@types/react": "18.3.12",
+    "@types/react-native": "0.72.6",
+    "@types/react-native-table-component": "1.2.8",
+    "@types/svg-parser": "^2.0.3",
+    "commitlint": "19.5.0",
+    "danger": "12.3.3",
+    "husky": "9.1.6",
+    "jest": "29.7.0",
+    "jest-environment-jsdom": "29.7.0",
+    "metro-react-native-babel-preset": "0.77.0",
+    "pod-install": "0.3.2",
+    "postinstall-postinstall": "2.1.0",
+    "react": "18.3.1",
+    "react-native": "0.72.6",
+    "react-native-builder-bob": "0.32.1",
+    "react-native-svg": "15.10.1",
+    "react-test-renderer": "18.3.1",
+    "reassure": "1.3.1",
+    "release-it": "17.10.0",
+    "typescript": "5.7.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+    "react-native": ">=0.60.0",
+    "react-native-svg": ">=12.3.0"
+  },
+  "jest": {
+    "preset": "react-native",
+    "testEnvironment": "jsdom",
+    "modulePathIgnorePatterns": [
+      "<rootDir>/examples/*/node_modules",
+      "<rootDir>/dist/"
+    ],
+    "setupFilesAfterEnv": [
+      "@testing-library/jest-native/extend-expect"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|react-native-table-component)"
+    ]
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ],
+    "rules": {
+      "type-enum": [
+        2,
+        "always",
+        [
+          "build",
+          "chore",
+          "ci",
+          "docs",
+          "feat",
+          "fix",
+          "perf",
+          "refactor",
+          "revert",
+          "style",
+          "test",
+          "todo",
+          "bump"
+        ]
+      ]
+    }
+  },
+  "release-it": {
+    "git": {
+      "commitMessage": "chore: release ${version}",
+      "tagName": "v${version}"
+    },
+    "npm": {
+      "publish": true
+    },
+    "github": {
+      "release": true,
+      "web": true
+    },
+    "plugins": {
+      "@release-it/conventional-changelog": {
+        "preset": "angular",
+        "ignoreRecommendedBump": true
+      }
+    }
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "dist",
+    "targets": [
+      "commonjs",
+      "module",
+      [
+        "typescript",
+        {
+          "project": "tsconfig.json"
+        }
+      ]
+    ]
+  },
+  "dependencies": {
+    "@jsamr/counter-style": "2.0.2",
+    "@jsamr/react-native-li": "2.3.1",
+    "html-entities": "2.5.2",
+    "marked": "5.0.5",
+    "react-native-table-component": "1.2.2",
+    "svg-parser": "2.0.4"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "resolutions": {
+    "@types/react": "18.3.12",
+    "@types/react-native": "0.72.6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,180 +1,172 @@
 {
-  "name": "react-native-marked",
-  "version": "6.0.6",
-  "description": "Markdown renderer for React Native powered by marked.js",
-  "main": "dist/commonjs/index",
-  "module": "dist/module/index",
-  "types": "dist/typescript/index.d.ts",
-  "react-native": "src/index",
-  "source": "src/index",
-  "files": [
-    "src",
-    "dist",
-    "android",
-    "ios",
-    "cpp",
-    "react-native-marked.podspec",
-    "!dist/typescript/example",
-    "!android/build",
-    "!ios/build",
-    "!**/__tests__",
-    "!**/__fixtures__",
-    "!**/__mocks__",
-    "!**/__perf__"
-  ],
-  "scripts": {
-    "typescript": "tsc --noEmit",
-    "lint": "biome check ./",
-    "format": "biome format ./ --write",
-    "build": "bob build",
-    "prepare": "yarn build",
-    "release": "yarn build && release-it",
-    "release:rc": "yarn build && release-it --preRelease=rc",
-    "release:exclude-pre": "yarn build && release-it --git.tagExclude='*[-]*'",
-    "test": "jest --passWithNoTests",
-    "test:updateSnapshot": "jest --updateSnapshot",
-    "reassure": "reassure"
-  },
-  "keywords": [
-    "react-native",
-    "markdown",
-    "react-native markdown"
-  ],
-  "repository": "https://github.com/gmsgowtham/react-native-marked",
-  "author": "Gowtham G <webappsbygowtham@gmail.com> (https://github.com/gmsgowtham)",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gmsgowtham/react-native-marked/issues"
-  },
-  "homepage": "https://github.com/gmsgowtham/react-native-marked#readme",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "devDependencies": {
-    "@babel/core": "7.26.0",
-    "@babel/helper-explode-assignable-expression": "7.18.6",
-    "@babel/preset-env": "7.26.0",
-    "@biomejs/biome": "1.9.4",
-    "@commitlint/config-conventional": "19.5.0",
-    "@evilmartians/lefthook": "1.8.2",
-    "@release-it/conventional-changelog": "9.0.4",
-    "@testing-library/jest-native": "5.4.3",
-    "@testing-library/react-native": "12.9.0",
-    "@types/jest": "29.5.14",
-    "@types/marked": "5.0.0",
-    "@types/node": "22.10.5",
-    "@types/react": "18.3.12",
-    "@types/react-native": "0.72.6",
-    "@types/react-native-table-component": "1.2.8",
-    "@types/svg-parser": "^2.0.3",
-    "commitlint": "19.5.0",
-    "danger": "12.3.3",
-    "husky": "9.1.6",
-    "jest": "29.7.0",
-    "jest-environment-jsdom": "29.7.0",
-    "metro-react-native-babel-preset": "0.77.0",
-    "pod-install": "0.3.2",
-    "postinstall-postinstall": "2.1.0",
-    "react": "18.3.1",
-    "react-native": "0.72.6",
-    "react-native-builder-bob": "0.32.1",
-    "react-native-svg": "15.10.1",
-    "react-test-renderer": "18.3.1",
-    "reassure": "1.3.1",
-    "release-it": "17.10.0",
-    "typescript": "5.7.2"
-  },
-  "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-    "react-native": ">=0.60.0",
-    "react-native-svg": ">=12.3.0"
-  },
-  "jest": {
-    "preset": "react-native",
-    "testEnvironment": "jsdom",
-    "modulePathIgnorePatterns": [
-      "<rootDir>/examples/*/node_modules",
-      "<rootDir>/dist/"
-    ],
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|react-native-table-component)"
-    ]
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ],
-    "rules": {
-      "type-enum": [
-        2,
-        "always",
-        [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "feat",
-          "fix",
-          "perf",
-          "refactor",
-          "revert",
-          "style",
-          "test",
-          "todo",
-          "bump"
-        ]
-      ]
-    }
-  },
-  "release-it": {
-    "git": {
-      "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}"
-    },
-    "npm": {
-      "publish": true
-    },
-    "github": {
-      "release": true,
-      "web": true
-    },
-    "plugins": {
-      "@release-it/conventional-changelog": {
-        "preset": "angular",
-        "ignoreRecommendedBump": true
-      }
-    }
-  },
-  "react-native-builder-bob": {
-    "source": "src",
-    "output": "dist",
-    "targets": [
-      "commonjs",
-      "module",
-      [
-        "typescript",
-        {
-          "project": "tsconfig.json"
-        }
-      ]
-    ]
-  },
-  "dependencies": {
-    "@jsamr/counter-style": "2.0.2",
-    "@jsamr/react-native-li": "2.3.1",
-    "html-entities": "2.5.2",
-    "marked": "5.0.5",
-    "react-native-table-component": "1.2.2",
-    "svg-parser": "2.0.4"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "resolutions": {
-    "@types/react": "18.3.12",
-    "@types/react-native": "0.72.6"
-  }
+	"name": "react-native-marked",
+	"version": "6.0.6",
+	"description": "Markdown renderer for React Native powered by marked.js",
+	"main": "dist/commonjs/index",
+	"module": "dist/module/index",
+	"types": "dist/typescript/index.d.ts",
+	"react-native": "src/index",
+	"source": "src/index",
+	"files": [
+		"src",
+		"dist",
+		"android",
+		"ios",
+		"cpp",
+		"react-native-marked.podspec",
+		"!dist/typescript/example",
+		"!android/build",
+		"!ios/build",
+		"!**/__tests__",
+		"!**/__fixtures__",
+		"!**/__mocks__",
+		"!**/__perf__"
+	],
+	"scripts": {
+		"typescript": "tsc --noEmit",
+		"lint": "biome check ./",
+		"format": "biome format ./ --write",
+		"build": "bob build",
+		"prepare": "yarn build",
+		"release": "yarn build && release-it",
+		"release:rc": "yarn build && release-it --preRelease=rc",
+		"release:exclude-pre": "yarn build && release-it --git.tagExclude='*[-]*'",
+		"test": "jest --passWithNoTests",
+		"test:updateSnapshot": "jest --updateSnapshot",
+		"reassure": "reassure"
+	},
+	"keywords": ["react-native", "markdown", "react-native markdown"],
+	"repository": "https://github.com/gmsgowtham/react-native-marked",
+	"author": "Gowtham G <webappsbygowtham@gmail.com> (https://github.com/gmsgowtham)",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/gmsgowtham/react-native-marked/issues"
+	},
+	"homepage": "https://github.com/gmsgowtham/react-native-marked#readme",
+	"publishConfig": {
+		"registry": "https://registry.npmjs.org/"
+	},
+	"devDependencies": {
+		"@babel/core": "7.26.0",
+		"@babel/helper-explode-assignable-expression": "7.18.6",
+		"@babel/preset-env": "7.26.0",
+		"@biomejs/biome": "1.9.4",
+		"@commitlint/config-conventional": "19.5.0",
+		"@evilmartians/lefthook": "1.8.2",
+		"@release-it/conventional-changelog": "9.0.4",
+		"@testing-library/jest-native": "5.4.3",
+		"@testing-library/react-native": "12.9.0",
+		"@types/jest": "29.5.14",
+		"@types/marked": "5.0.0",
+		"@types/node": "22.10.5",
+		"@types/react": "18.3.12",
+		"@types/react-native": "0.72.6",
+		"@types/react-native-table-component": "1.2.8",
+		"@types/svg-parser": "^2.0.3",
+		"commitlint": "19.5.0",
+		"danger": "12.3.3",
+		"husky": "9.1.6",
+		"jest": "29.7.0",
+		"jest-environment-jsdom": "29.7.0",
+		"metro-react-native-babel-preset": "0.77.0",
+		"pod-install": "0.3.2",
+		"postinstall-postinstall": "2.1.0",
+		"react": "18.3.1",
+		"react-native": "0.72.6",
+		"react-native-builder-bob": "0.32.1",
+		"react-native-svg": "15.10.1",
+		"react-test-renderer": "18.3.1",
+		"reassure": "1.3.1",
+		"release-it": "17.10.0",
+		"typescript": "5.7.2"
+	},
+	"peerDependencies": {
+		"react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+		"react-native": ">=0.60.0",
+		"react-native-svg": ">=12.3.0"
+	},
+	"jest": {
+		"preset": "react-native",
+		"testEnvironment": "jsdom",
+		"modulePathIgnorePatterns": [
+			"<rootDir>/examples/*/node_modules",
+			"<rootDir>/dist/"
+		],
+		"setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"],
+		"transformIgnorePatterns": [
+			"node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|react-native-table-component)"
+		]
+	},
+	"commitlint": {
+		"extends": ["@commitlint/config-conventional"],
+		"rules": {
+			"type-enum": [
+				2,
+				"always",
+				[
+					"build",
+					"chore",
+					"ci",
+					"docs",
+					"feat",
+					"fix",
+					"perf",
+					"refactor",
+					"revert",
+					"style",
+					"test",
+					"todo",
+					"bump"
+				]
+			]
+		}
+	},
+	"release-it": {
+		"git": {
+			"commitMessage": "chore: release ${version}",
+			"tagName": "v${version}"
+		},
+		"npm": {
+			"publish": true
+		},
+		"github": {
+			"release": true,
+			"web": true
+		},
+		"plugins": {
+			"@release-it/conventional-changelog": {
+				"preset": "angular",
+				"ignoreRecommendedBump": true
+			}
+		}
+	},
+	"react-native-builder-bob": {
+		"source": "src",
+		"output": "dist",
+		"targets": [
+			"commonjs",
+			"module",
+			[
+				"typescript",
+				{
+					"project": "tsconfig.json"
+				}
+			]
+		]
+	},
+	"dependencies": {
+		"@jsamr/counter-style": "2.0.2",
+		"@jsamr/react-native-li": "2.3.1",
+		"html-entities": "2.5.2",
+		"marked": "5.0.5",
+		"react-native-table-component": "1.2.2",
+		"svg-parser": "2.0.4"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"resolutions": {
+		"@types/react": "18.3.12",
+		"@types/react-native": "0.72.6"
+	}
 }


### PR DESCRIPTION
Making react-native-svg a dev dependency allows apps which are using a different version of react-native-svg to use this library without issues. This works since it is already listed as a peer dependency.

This fixes https://github.com/gmsgowtham/react-native-marked/issues/782 and related issues