### PR TITLE
fix(minor): drop memoizing Markdown component

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,7 @@
 		"test:updateSnapshot": "jest --updateSnapshot",
 		"reassure": "reassure"
 	},
-	"keywords": [
-		"react-native",
-		"markdown",
-		"react-native markdown"
-	],
+	"keywords": ["react-native", "markdown", "react-native markdown"],
 	"repository": "https://github.com/gmsgowtham/react-native-marked",
 	"author": "Gowtham G <webappsbygowtham@gmail.com> (https://github.com/gmsgowtham)",
 	"license": "MIT",
@@ -97,9 +93,7 @@
 		]
 	},
 	"commitlint": {
-		"extends": [
-			"@commitlint/config-conventional"
-		],
+		"extends": ["@commitlint/config-conventional"],
 		"rules": {
 			"type-enum": [
 				2,

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -1,9 +1,4 @@
-import React, {
-	memo,
-	useCallback,
-	type ReactElement,
-	type ReactNode,
-} from "react";
+import React, { useCallback, type ReactElement, type ReactNode } from "react";
 import { FlatList, useColorScheme } from "react-native";
 import type { MarkdownProps } from "./types";
 import useMarkdown from "../hooks/useMarkdown";
@@ -53,4 +48,4 @@ const Markdown = ({
 	);
 };
 
-export default memo(Markdown);
+export default Markdown;


### PR DESCRIPTION
To avoid facing the following error

```
'Markdown' cannot be used as a JSX component.
Its type 'MemoExoticComponent
```