### PR TITLE
feat: make selectable optional for Text elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ export default ExampleComponent;
 | baseUrl       | A prefix url for any relative link                                                                                                           | string                                                                                                                                                                         | true      |
 | renderer      | Custom component Renderer                                                                                                                    | [RendererInterface](src/lib/types.ts)                                                                                                                                          | true      |
 | hooks         | Hooks run during parsing to transform tokens                                                                                                | [Marked Hooks](https://marked.js.org/using_pro#hooks)                                                                                                                            | true      |
+| selectable    | Whether Text elements are selectable. Defaults to `true`. When a custom `renderer` is provided, this prop is ignored — configure via `new Renderer({ selectable })`. | boolean                                                                                                                                                                          | true      |
 
 
 ### Using hook
@@ -91,8 +92,8 @@ const CustomComponent = () => {
 | baseUrl     | A prefix url for any relative link                                                                                                           | string                                           | true      |
 | renderer    | Custom component Renderer                                                                                                                    | [RendererInterface](src/lib/types.ts)            | true      |
 | tokenizer   | Generate custom tokens                                                                                                                       | [MarkedTokenizer<CustomToken>](src/lib/types.ts) | true      |
-| hooks       | Hooks run during parsing to transform tokens                                                                                                 |
-[Marked Hooks](https://marked.js.org/using_pro#hooks)   | true      |
+| hooks       | Hooks run during parsing to transform tokens                                                                                                 | [Marked Hooks](https://marked.js.org/using_pro#hooks) | true      |
+| selectable  | Whether Text elements are selectable. Defaults to `true`. When a custom `renderer` is provided, this option is ignored — configure via `new Renderer({ selectable })`. | boolean                                          | true      |
 
 
 ## Examples

--- a/src/hooks/useMarkdown.ts
+++ b/src/hooks/useMarkdown.ts
@@ -15,6 +15,7 @@ export interface useMarkdownHookOptions {
 	baseUrl?: string;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;
+	selectable?: boolean;
 }
 
 const useMarkdown = (
@@ -31,9 +32,11 @@ const useMarkdown = (
 			new Parser({
 				styles: styles,
 				baseUrl: options?.baseUrl,
-				renderer: options?.renderer ?? new Renderer(),
+				renderer:
+					options?.renderer ??
+					new Renderer({ selectable: options?.selectable }),
 			}),
-		[options?.renderer, options?.baseUrl, styles],
+		[options?.renderer, options?.baseUrl, styles, options?.selectable],
 	);
 
 	const elements = useMemo(() => {

--- a/src/hooks/useMarkdown.ts
+++ b/src/hooks/useMarkdown.ts
@@ -9,12 +9,14 @@ import type { MarkedStyles, UserTheme } from "./../theme/types";
 
 export interface useMarkdownHookOptions {
 	colorScheme?: ColorSchemeName;
+	/** Custom renderer. When provided, `selectable` is ignored — configure via `new Renderer({ selectable })`. */
 	renderer?: RendererInterface;
 	theme?: UserTheme;
 	styles?: MarkedStyles;
 	baseUrl?: string;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;
+	/** Whether Text elements are selectable. Defaults to `true`. Ignored when `renderer` is provided. */
 	selectable?: boolean;
 }
 

--- a/src/hooks/useMarkdownWithComponents.tsx
+++ b/src/hooks/useMarkdownWithComponents.tsx
@@ -46,8 +46,9 @@ export function useMarkdownWithComponents(
 	}, []);
 
 	const baseRenderer = useMemo(
-		() => options?.renderer ?? new Renderer(),
-		[options?.renderer],
+		() =>
+			options?.renderer ?? new Renderer({ selectable: options?.selectable }),
+		[options?.renderer, options?.selectable],
 	);
 
 	const renderer = useMemo<RendererInterface>(() => {

--- a/src/hooks/useMarkdownWithComponents.tsx
+++ b/src/hooks/useMarkdownWithComponents.tsx
@@ -52,6 +52,10 @@ export function useMarkdownWithComponents(
 	);
 
 	const renderer = useMemo<RendererInterface>(() => {
+		// Use prototype delegation so all Renderer methods (text, link, getTextNode -> selectable,
+		// getKey -> slugger) resolve via baseRenderer's prototype. Only `html` is overridden here
+		// for component registry handling. Avoids copying private fields and keeps `this` binding
+		// consistent. If Renderer ever uses #private fields this pattern will need revisiting.
 		const wrappedRenderer = Object.create(baseRenderer) as typeof baseRenderer;
 
 		wrappedRenderer.html = (text: string | ReactNode[], styles): ReactNode => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import useMarkdownWithComponents from "./hooks/useMarkdownWithComponents";
 import Markdown from "./lib/Markdown";
 import type { ReactComponentRegistry } from "./lib/ReactComponentRegistry";
 import { ReactComponentRegistryProvider } from "./lib/ReactComponentRegistry";
-import Renderer from "./lib/Renderer";
+import Renderer, { type RendererOptions } from "./lib/Renderer";
 import type {
 	MarkdownProps,
 	ParserOptions,
@@ -25,6 +25,7 @@ export type {
 	ParserOptions,
 	ReactComponentRegistry,
 	RendererInterface,
+	RendererOptions,
 	Token,
 	Tokens,
 	useMarkdownHookOptions,

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -12,6 +12,7 @@ const Markdown = ({
 	styles,
 	tokenizer,
 	hooks,
+	selectable,
 }: MarkdownProps) => {
 	const colorScheme = useColorScheme();
 
@@ -23,6 +24,7 @@ const Markdown = ({
 		styles,
 		tokenizer,
 		hooks,
+		selectable,
 	});
 
 	const renderItem = useCallback(({ item }: { item: ReactNode }) => {

--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -19,6 +19,9 @@ import { getTableWidthArr } from "../utils/table";
 import type { RendererInterface } from "./types";
 
 export interface RendererOptions {
+	/**
+	 * Whether Text elements are selectable. Defaults to `true`.
+	 */
 	selectable?: boolean;
 }
 

--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -18,14 +18,20 @@ import { onLinkPress } from "../utils/handlers";
 import { getTableWidthArr } from "../utils/table";
 import type { RendererInterface } from "./types";
 
+export interface RendererOptions {
+	selectable?: boolean;
+}
+
 class Renderer implements RendererInterface {
 	private slugPrefix = "react-native-marked-ele";
 	private slugger: Slugger;
 	private windowWidth: number;
-	constructor() {
+	private selectable: boolean;
+	constructor(options?: RendererOptions) {
 		this.slugger = new Slugger();
 		const { width } = Dimensions.get("window");
 		this.windowWidth = width;
+		this.selectable = options?.selectable ?? true;
 	}
 
 	paragraph(children: ReactNode[], styles?: ViewStyle): ReactNode {
@@ -101,7 +107,7 @@ class Renderer implements RendererInterface {
 	): ReactNode {
 		return (
 			<Text
-				selectable
+				selectable={this.selectable}
 				accessibilityRole="link"
 				accessibilityHint="Opens in a new window"
 				accessibilityLabel={title || "Link"}
@@ -206,7 +212,7 @@ class Renderer implements RendererInterface {
 		styles?: TextStyle,
 	): ReactNode {
 		return (
-			<Text selectable key={this.getKey()} style={styles}>
+			<Text selectable={this.selectable} key={this.getKey()} style={styles}>
 				{children}
 			</Text>
 		);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface MarkdownProps extends Partial<ParserOptions> {
 	theme?: UserTheme;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;
+	selectable?: boolean;
 }
 
 export type TableColAlignment = "center" | "left" | "right" | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,11 @@ export interface MarkdownProps extends Partial<ParserOptions> {
 	theme?: UserTheme;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;
+	/**
+	 * Whether Text elements are selectable. Defaults to `true`.
+	 * When a custom `renderer` is provided this prop is ignored —
+	 * configure the renderer directly via `new Renderer({ selectable })`.
+	 */
 	selectable?: boolean;
 }
 


### PR DESCRIPTION
Adds selectable option to Markdown component, useMarkdown and useMarkdownWithComponents hooks, and Renderer class to allow disabling text selection. Previously selectable was hardcoded to true for all Text elements, preventing customization for apps with custom context menus (e.g., iOS Copy popover). The new selectable prop defaults to true for backward compatibility and can be set to false to disable selection.

Fixes #901