### PR TITLE
fix: ensure fontFamily style is applied to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ Ref: [CommonMark](https://commonmark.org/help/)
 
 > HTML will be treated as plain text. Please refer [issue#290](https://github.com/gmsgowtham/react-native-marked/issues/290) for a potential solution
 
+### Styling code blocks and inline code
+
+Use `code` for the block container (`ViewStyle`) and `codeText` / `codespan` for the text (`TextStyle`) to guarantee `fontFamily` (and other `TextStyle` props) are applied:
+
+```tsx
+<Markdown
+  value={"```js\nconsole.log('hello')\n```\n\nUse `inline` code"}
+  styles={{
+    code: { backgroundColor: "#f6f8fa", padding: 16 }, // ViewStyle – container
+    codeText: { fontFamily: "Menlo", fontSize: 14 }, // TextStyle – code block text
+    codespan: { fontFamily: "Menlo", backgroundColor: "#f6f8fa" }, // TextStyle – inline
+  }}
+/>
+```
+
+`codeText` was introduced to replace the previous `em`-based fallback for code blocks and ensures all `TextStyle` props win over parent styles.
+
 ## Advanced
 
 ### Embedding React Components in Markdown

--- a/src/lib/Parser.tsx
+++ b/src/lib/Parser.tsx
@@ -75,7 +75,7 @@ class Parser {
 					token.text,
 					token.lang,
 					this.styles.code,
-					this.styles.em,
+					this.styles.codeText,
 				);
 			}
 			case "hr": {
@@ -179,8 +179,8 @@ class Parser {
 			}
 			case "codespan": {
 				return this.renderer.codespan(decode(token.text), {
+					...(styles as TextStyle),
 					...this.styles.codespan,
-					...styles,
 				});
 			}
 			case "br": {

--- a/src/lib/__tests__/Renderer.spec.tsx
+++ b/src/lib/__tests__/Renderer.spec.tsx
@@ -4,10 +4,11 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react-native";
-import type { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { type ColorSchemeName, Linking } from "react-native";
 import getStyles from "../../theme/styles";
 import type { MarkedStyles } from "../../theme/types";
+import Markdown from "../Markdown";
 import Renderer from "../Renderer";
 
 jest.mock("react-native/Libraries/Linking/Linking", () => ({
@@ -243,4 +244,93 @@ describe("Renderer", () => {
 			});
 		});
 	}
+});
+
+describe("code and codespan styles #873", () => {
+	it("code block uses codeText style", () => {
+		const r = render(
+			<Markdown
+				value={"```\nhello\n```"}
+				styles={{ codeText: { fontFamily: "Menlo" } }}
+			/>,
+		);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
+
+	it("code block with all TextStyle props via codeText", () => {
+		const r = render(
+			<Markdown
+				value={"```\ncode\n```"}
+				styles={{
+					codeText: {
+						fontFamily: "Menlo",
+						fontSize: 14,
+						color: "#ff0000",
+						fontWeight: "700",
+					},
+				}}
+			/>,
+		);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
+
+	it("code block uses codeText instead of em (not italic)", () => {
+		const r = render(<Markdown value={"```\ncode\n```"} />);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
+
+	it("code container ViewStyle and codeText TextStyle", () => {
+		const styles = getStyles(
+			{
+				code: { padding: 10, backgroundColor: "#fff" },
+				codeText: { fontFamily: "Menlo" },
+			},
+			"light",
+		);
+		expect(styles.code?.padding).toBe(10);
+		expect(styles.codeText?.fontFamily).toBe("Menlo");
+	});
+
+	it("codespan preserves style inside strong", () => {
+		const r = render(
+			<Markdown
+				value={"**some `code` inside**"}
+				styles={{
+					codespan: { fontFamily: "Menlo" },
+					strong: { fontFamily: "Helvetica-Bold" } as never,
+				}}
+			/>,
+		);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
+
+	it("codespan preserves style inside em", () => {
+		const r = render(
+			<Markdown
+				value={"*some `code` inside*"}
+				styles={{
+					codespan: { fontFamily: "Menlo" },
+					em: { fontFamily: "Helvetica-Oblique" } as never,
+				}}
+			/>,
+		);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
+
+	it("codespan with all TextStyle props", () => {
+		const r = render(
+			<Markdown
+				value={"Use `code` here"}
+				styles={{
+					codespan: {
+						fontFamily: "Menlo",
+						fontSize: 14,
+						color: "#ff0000",
+						fontWeight: "700",
+					},
+				}}
+			/>,
+		);
+		expect(r.toJSON()).toMatchSnapshot();
+	});
 });

--- a/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
@@ -954,7 +954,8 @@ exports[`Code Code Blocks (backtick) 1`] = `
               {
                 "color": "#333333",
                 "fontSize": 16,
-                "fontStyle": "italic",
+                "fontStyle": "normal",
+                "fontWeight": "400",
                 "lineHeight": 24,
               }
             }
@@ -1014,7 +1015,8 @@ exports[`Code Code Blocks (backtick) 1`] = `
                 {
                   "color": "#333333",
                   "fontSize": 16,
-                  "fontStyle": "italic",
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
                   "lineHeight": 24,
                 }
               }
@@ -1052,7 +1054,8 @@ exports[`Code Code Blocks (backtick), no ending backtick 1`] = `
               {
                 "color": "#333333",
                 "fontSize": 16,
-                "fontStyle": "italic",
+                "fontStyle": "normal",
+                "fontWeight": "400",
                 "lineHeight": 24,
               }
             }
@@ -1112,7 +1115,8 @@ exports[`Code Code Blocks (backtick), no ending backtick 1`] = `
                 {
                   "color": "#333333",
                   "fontSize": 16,
-                  "fontStyle": "italic",
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
                   "lineHeight": 24,
                 }
               }
@@ -1150,7 +1154,8 @@ exports[`Code Code Blocks 1`] = `
               {
                 "color": "#333333",
                 "fontSize": 16,
-                "fontStyle": "italic",
+                "fontStyle": "normal",
+                "fontWeight": "400",
                 "lineHeight": 24,
               }
             }
@@ -1211,7 +1216,8 @@ exports[`Code Code Blocks 1`] = `
                 {
                   "color": "#333333",
                   "fontSize": 16,
-                  "fontStyle": "italic",
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
                   "lineHeight": 24,
                 }
               }
@@ -4665,7 +4671,7 @@ See the section on
               style={
                 {
                   "backgroundColor": "#f6f8fa",
-                  "color": "#58a6ff",
+                  "color": "#333333",
                   "fontSize": 16,
                   "fontStyle": "italic",
                   "fontWeight": "300",
@@ -4849,7 +4855,7 @@ See the section on
               style={
                 {
                   "backgroundColor": "#f6f8fa",
-                  "color": "#58a6ff",
+                  "color": "#333333",
                   "fontSize": 16,
                   "fontStyle": "italic",
                   "fontWeight": "300",
@@ -5856,7 +5862,8 @@ exports[`Lists Elements in Lists: Code Blocks 1`] = `
                       {
                         "color": "#333333",
                         "fontSize": 16,
-                        "fontStyle": "italic",
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
                         "lineHeight": 24,
                       }
                     }
@@ -6117,7 +6124,8 @@ exports[`Lists Elements in Lists: Code Blocks 1`] = `
                     {
                       "color": "#333333",
                       "fontSize": 16,
-                      "fontStyle": "italic",
+                      "fontStyle": "normal",
+                      "fontWeight": "400",
                       "lineHeight": 24,
                     }
                   }

--- a/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
@@ -1509,3 +1509,801 @@ exports[`Renderer light theme getListNode returns Un-Ordered List 1`] = `
   </Text>
 </View>
 `;
+
+exports[`code and codespan styles #873 code block uses codeText instead of em (not italic) 1`] = `
+<RCTScrollView
+  data={
+    [
+      <ScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontSize": 16,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "lineHeight": 24,
+              }
+            }
+          >
+            code
+          </Text>
+        </View>
+      </ScrollView>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <View>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+          </View>
+        </View>
+      </RCTScrollView>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`code and codespan styles #873 code block uses codeText style 1`] = `
+<RCTScrollView
+  data={
+    [
+      <ScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontFamily": "Menlo",
+                "fontSize": 16,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "lineHeight": 24,
+              }
+            }
+          >
+            hello
+          </Text>
+        </View>
+      </ScrollView>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <View>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Menlo",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              hello
+            </Text>
+          </View>
+        </View>
+      </RCTScrollView>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`code and codespan styles #873 code block with all TextStyle props via codeText 1`] = `
+<RCTScrollView
+  data={
+    [
+      <ScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#ff0000",
+                "fontFamily": "Menlo",
+                "fontSize": 14,
+                "fontStyle": "normal",
+                "fontWeight": "700",
+                "lineHeight": 24,
+              }
+            }
+          >
+            code
+          </Text>
+        </View>
+      </ScrollView>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          {
+            "backgroundColor": "#f6f8fa",
+            "minWidth": "100%",
+            "padding": 16,
+          }
+        }
+        horizontal={true}
+      >
+        <View>
+          <View>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#ff0000",
+                  "fontFamily": "Menlo",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "700",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+          </View>
+        </View>
+      </RCTScrollView>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`code and codespan styles #873 codespan preserves style inside em 1`] = `
+<RCTScrollView
+  data={
+    [
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontFamily": "Helvetica-Oblique",
+                "fontSize": 16,
+                "fontStyle": "italic",
+                "lineHeight": 24,
+              }
+            }
+          >
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Oblique",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              some 
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "backgroundColor": "#f6f8fa",
+                  "color": "#333333",
+                  "fontFamily": "Menlo",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "fontWeight": "300",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Oblique",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "lineHeight": 24,
+                }
+              }
+            >
+               inside
+            </Text>
+          </Text>
+        </Text>
+      </View>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontFamily": "Helvetica-Oblique",
+                "fontSize": 16,
+                "fontStyle": "italic",
+                "lineHeight": 24,
+              }
+            }
+          >
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Oblique",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              some 
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "backgroundColor": "#f6f8fa",
+                  "color": "#333333",
+                  "fontFamily": "Menlo",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "fontWeight": "300",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Oblique",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "lineHeight": 24,
+                }
+              }
+            >
+               inside
+            </Text>
+          </Text>
+        </Text>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`code and codespan styles #873 codespan preserves style inside strong 1`] = `
+<RCTScrollView
+  data={
+    [
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontFamily": "Helvetica-Bold",
+                "fontSize": 16,
+                "fontWeight": "bold",
+                "lineHeight": 24,
+              }
+            }
+          >
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Bold",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              some 
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "backgroundColor": "#f6f8fa",
+                  "color": "#333333",
+                  "fontFamily": "Menlo",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "fontWeight": "300",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Bold",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "lineHeight": 24,
+                }
+              }
+            >
+               inside
+            </Text>
+          </Text>
+        </Text>
+      </View>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontFamily": "Helvetica-Bold",
+                "fontSize": 16,
+                "fontWeight": "bold",
+                "lineHeight": 24,
+              }
+            }
+          >
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Bold",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              some 
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "backgroundColor": "#f6f8fa",
+                  "color": "#333333",
+                  "fontFamily": "Menlo",
+                  "fontSize": 16,
+                  "fontStyle": "italic",
+                  "fontWeight": "300",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              code
+            </Text>
+            <Text
+              selectable={true}
+              style={
+                {
+                  "color": "#333333",
+                  "fontFamily": "Helvetica-Bold",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "lineHeight": 24,
+                }
+              }
+            >
+               inside
+            </Text>
+          </Text>
+        </Text>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`code and codespan styles #873 codespan with all TextStyle props 1`] = `
+<RCTScrollView
+  data={
+    [
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Use 
+          </Text>
+          <Text
+            selectable={true}
+            style={
+              {
+                "backgroundColor": "#f6f8fa",
+                "color": "#ff0000",
+                "fontFamily": "Menlo",
+                "fontSize": 14,
+                "fontStyle": "italic",
+                "fontWeight": "700",
+                "lineHeight": 24,
+              }
+            }
+          >
+            code
+          </Text>
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+             here
+          </Text>
+        </Text>
+      </View>,
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  initialNumToRender={8}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={8}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={0.0001}
+  stickyHeaderIndices={[]}
+  style={
+    {
+      "backgroundColor": "#ffffff",
+    }
+  }
+  viewabilityConfigCallbackPairs={[]}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          {
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          selectable={true}
+          style={{}}
+        >
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Use 
+          </Text>
+          <Text
+            selectable={true}
+            style={
+              {
+                "backgroundColor": "#f6f8fa",
+                "color": "#ff0000",
+                "fontFamily": "Menlo",
+                "fontSize": 14,
+                "fontStyle": "italic",
+                "fontWeight": "700",
+                "lineHeight": 24,
+              }
+            }
+          >
+            code
+          </Text>
+          <Text
+            selectable={true}
+            style={
+              {
+                "color": "#333333",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+             here
+          </Text>
+        </Text>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -151,6 +151,14 @@ const getStyles = (
 			},
 			userStyles?.code,
 		]),
+		codeText: StyleSheet.flatten([
+			fontStyle.regular,
+			{
+				fontStyle: "normal",
+				fontWeight: "400",
+			},
+			userStyles?.codeText,
+		]),
 		hr: StyleSheet.flatten([
 			{
 				borderBottomWidth: 1,

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -18,6 +18,7 @@ export interface MarkedStyles {
 	h6?: TextStyle;
 	codespan?: TextStyle;
 	code?: ViewStyle;
+	codeText?: TextStyle;
 	hr?: ViewStyle;
 	list?: ViewStyle;
 	li?: TextStyle;


### PR DESCRIPTION
Fixes #873

**Problem**
fontFamily (and other TextStyle props) passed via styles.code / styles.codespan was not reliably applied. Code blocks used styles.em (italic) for Text and styles.code only for container (ViewStyle). codespan merged as {...codespan, ...parent} so parent strong/em overrode codespan fontFamily.

**Solution**
- src/theme/types.ts – add MarkedStyles.codeText?: TextStyle; keep code as ViewStyle (container) for back-compat
- src/theme/styles.ts – add codeText style (regular + normal, user override)
- src/lib/Parser.tsx – code blocks now use codeText (instead of em); codespan merges as {...parent, ...codespan} so codespan TextStyle wins (all applicable props)
- src/lib/Renderer.tsx – simplified (no TEXT_STYLE_KEYS, ViewStyle only)
- Tests – moved to snapshot-based suite in Renderer.spec (code and codespan styles #873, 7 snapshots)

**Validation**
- yarn typescript, yarn build, yarn test --no-coverage 9 suites 152 tests 93 snapshots pass
