### PR TITLE
feat!: prevent FlatList item re-rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,35 @@ const ExampleComponent = () => {
 export default ExampleComponent;
 ```
 
-#### [Props](https://github.com/gmsgowtham/react-native-marked/blob/main/src/lib/types.ts#L17)
+#### [Props](https://github.com/gmsgowtham/react-native-marked/blob/main/src/lib/types.ts#L24)
 
-| Prop          | Description                                                                                                                                  | Type                                                                                                                                                                           | Optional? |
-|---------------|----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| value         | Markdown value                                                                                                                               | string                                                                                                                                                                         | false     |
-| flatListProps | Props for customizing the underlying FlatList used                                                                                           | `Omit<FlatListProps<ReactNode>, 'data' \| 'renderItem' \| 'horizontal'>`<br><br><br>(`'data'`, `'renderItem'`, and `'horizontal'` props are omitted and cannot be overridden.) | true      |
-| styles        | Styles for parsed components                                                                                                                 | [MarkedStyles](src/theme/types.ts)                                                                                                                                             | true      |
-| theme         | Props for customizing colors and spacing for all components,and it will get overridden with custom component style applied via 'styles' prop | [UserTheme](src/theme/types.ts)                                                                                                                                                | true      |
-| baseUrl       | A prefix url for any relative link                                                                                                           | string                                                                                                                                                                         | true      |
-| renderer      | Custom component Renderer                                                                                                                    | [RendererInterface](src/lib/types.ts)                                                                                                                                          | true      |
-| hooks         | Hooks run during parsing to transform tokens                                                                                                | [Marked Hooks](https://marked.js.org/using_pro#hooks)                                                                                                                            | true      |
-| selectable    | Whether Text elements are selectable. Defaults to `true`. When a custom `renderer` is provided, this prop is ignored — configure via `new Renderer({ selectable })`. | boolean                                                                                                                                                                          | true      |
+| Prop          | Description                                                                                                                                                                                                     | Type                                                                                                                                                                             | Optional? |
+|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| value         | Markdown value                                                                                                                                                                                                  | string                                                                                                                                                                           | false     |
+| flatListProps | Props for customizing the underlying FlatList used. Pass `null` to disable virtualization and render with `ScrollView` (useful for small docs). Stable content-derived keys prevent unnecessary re-renders (#451). | `Omit<FlatListProps<MarkdownBlock>, 'data' \| 'renderItem' \| 'horizontal'> \| null`<br><br>(`'data'`, `'renderItem'`, and `'horizontal'` props are omitted and cannot be overridden. `null` disables FlatList.) | true      |
+| styles        | Styles for parsed components                                                                                                                                                                                    | [MarkedStyles](src/theme/types.ts)                                                                                                                                               | true      |
+| theme         | Props for customizing colors and spacing for all components,and it will get overridden with custom component style applied via 'styles' prop                                                                    | [UserTheme](src/theme/types.ts)                                                                                                                                                  | true      |
+| baseUrl       | A prefix url for any relative link                                                                                                                                                                              | string                                                                                                                                                                           | true      |
+| renderer      | Custom component Renderer                                                                                                                                                                                       | [RendererInterface](src/lib/types.ts)                                                                                                                                            | true      |
+| hooks         | Hooks run during parsing to transform tokens                                                                                                                                                                   | [Marked Hooks](https://marked.js.org/using_pro#hooks)                                                                                                                           | true      |
+| selectable    | Whether Text elements are selectable. Defaults to `true`. When a custom `renderer` is provided, this prop is ignored — configure via `new Renderer({ selectable })`.                                           | boolean                                                                                                                                                                            | true      |
 
 
-### Using hook
+### Using hooks
 
-`useMarkdown` hook will return list of elements that can be rendered using a list component of your choice.
+`useMarkdown` hook will return list of elements that can be rendered using a list component of your choice. Elements are memoized with stable references — only changed blocks re-parse (#451), ideal for chat streaming where `value` grows incrementally.
+
+`useMarkdownBlocks` (new) returns `{ blocks: MarkdownBlock[], parser }` for FlatList-optimized rendering with stable `id` keys (content-hash + index, `src/lib/types.ts:17`). Use it when you need virtualization control:
+
+```tsx
+import { useMarkdownBlocks } from "react-native-marked";
+import MarkdownBlock from "react-native-marked/src/lib/MarkdownBlock";
+
+const { blocks, parser } = useMarkdownBlocks(value, { theme, styles });
+<FlatList data={blocks} keyExtractor={b => b.id} renderItem={({item})=> <MarkdownBlock token={item.token} parser={parser} blockId={item.id}/>} />
+```
+
+> **Performance note:** Memoize `styles`/`theme`/`renderer` objects with `useMemo` — new object identities force full re-parse ( `src/hooks/useMarkdown.ts:27`, `src/hooks/useMarkdownBlocks.ts:37`). Pass `flatListProps={null}` for non-virtualized `ScrollView` on small docs.
 
 ```tsx
 import React, { Fragment } from "react";

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default ExampleComponent;
 | Prop          | Description                                                                                                                                                                                                     | Type                                                                                                                                                                             | Optional? |
 |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | value         | Markdown value                                                                                                                                                                                                  | string                                                                                                                                                                           | false     |
-| flatListProps | Props for customizing the underlying FlatList used. Pass `null` to disable virtualization and render with `ScrollView` (useful for small docs). Stable content-derived keys prevent unnecessary re-renders (#451). | `Omit<FlatListProps<MarkdownBlock>, 'data' \| 'renderItem' \| 'horizontal'> \| null`<br><br>(`'data'`, `'renderItem'`, and `'horizontal'` props are omitted and cannot be overridden. `null` disables FlatList.) | true      |
+| flatListProps | Props for customizing the underlying FlatList used. Pass `null` to disable virtualization and render with `ScrollView` (useful for small docs). Stable content-derived keys prevent unnecessary re-renders (#451). | `Omit<FlatListProps<MarkdownBlock>, 'data' \| 'renderItem' \| 'horizontal'> \| Omit<FlatListProps<ReactNode>, 'data' \| 'renderItem' \| 'horizontal'> \| null`<br><br>(`'data'`, `'renderItem'`, and `'horizontal'` props are omitted and cannot be overridden. `ReactNode` item props remain accepted for backward compatibility. `null` disables FlatList.) | true      |
 | styles        | Styles for parsed components                                                                                                                                                                                    | [MarkedStyles](src/theme/types.ts)                                                                                                                                               | true      |
 | theme         | Props for customizing colors and spacing for all components,and it will get overridden with custom component style applied via 'styles' prop                                                                    | [UserTheme](src/theme/types.ts)                                                                                                                                                  | true      |
 | baseUrl       | A prefix url for any relative link                                                                                                                                                                              | string                                                                                                                                                                           | true      |
@@ -63,14 +63,13 @@ export default ExampleComponent;
 
 `useMarkdown` hook will return list of elements that can be rendered using a list component of your choice. Elements are memoized with stable references — only changed blocks re-parse (#451), ideal for chat streaming where `value` grows incrementally.
 
-`useMarkdownBlocks` (new) returns `{ blocks: MarkdownBlock[], parser }` for FlatList-optimized rendering with stable `id` keys (content-hash + index, `src/lib/types.ts:17`). Use it when you need virtualization control:
+`useMarkdownBlocks` (new) returns `{ blocks: MarkdownBlock[], parser }` for FlatList-optimized rendering with stable content-derived `id` keys (`src/lib/types.ts:17`, `src/lib/blockUtils.ts`). Use it when you need virtualization control:
 
 ```tsx
-import { useMarkdownBlocks } from "react-native-marked";
-import MarkdownBlock from "react-native-marked/src/lib/MarkdownBlock";
+import { MarkdownBlockView, useMarkdownBlocks } from "react-native-marked";
 
 const { blocks, parser } = useMarkdownBlocks(value, { theme, styles });
-<FlatList data={blocks} keyExtractor={b => b.id} renderItem={({item})=> <MarkdownBlock token={item.token} parser={parser} blockId={item.id}/>} />
+<FlatList data={blocks} keyExtractor={b => b.id} renderItem={({item})=> <MarkdownBlockView token={item.token} parser={parser} blockId={item.id}/>} />
 ```
 
 > **Performance note:** Memoize `styles`/`theme`/`renderer` objects with `useMemo` — new object identities force full re-parse ( `src/hooks/useMarkdown.ts:27`, `src/hooks/useMarkdownBlocks.ts:37`). Pass `flatListProps={null}` for non-virtualized `ScrollView` on small docs.

--- a/docs/docs/api/hooks.md
+++ b/docs/docs/api/hooks.md
@@ -10,6 +10,28 @@ function useMarkdown(value: string, options: useMarkdownHookOptions): ReactNode[
 
 `options.colorScheme` is required; rest mirrors `MarkdownProps` plus `tokenizer`.
 
+## useMarkdownBlocks (`src/hooks/useMarkdownBlocks.ts`)
+
+Returns `{ blocks: MarkdownBlock[], parser }` for FlatList-optimized rendering
+with stable content-derived `id` keys. Only new/changed blocks re-parse when
+`value` changes (#451):
+
+```tsx
+import { MarkdownBlockView, useMarkdownBlocks } from "react-native-marked";
+
+const { blocks, parser } = useMarkdownBlocks(value, { theme, styles });
+<FlatList
+  data={blocks}
+  keyExtractor={(block) => block.id}
+  renderItem={({ item }) => (
+    <MarkdownBlockView token={item.token} parser={parser} blockId={item.id} />
+  )}
+/>
+```
+
+> Memoize `styles` / `theme` / `renderer` objects with `useMemo` — new object
+> identities force full re-parse.
+
 ## useMarkdownWithComponents (`src/hooks/useMarkdownWithComponents.tsx`)
 
 ```ts

--- a/docs/docs/api/markdown-props.md
+++ b/docs/docs/api/markdown-props.md
@@ -9,7 +9,9 @@ interface ParserOptions {
 
 interface MarkdownProps extends Partial<ParserOptions> {
   value: string;
-  flatListProps?: Omit<FlatListProps<ReactNode>, "data"|"renderItem"|"horizontal">;
+  flatListProps?: Omit<FlatListProps<MarkdownBlock>, "data"|"renderItem"|"horizontal">
+    | Omit<FlatListProps<ReactNode>, "data"|"renderItem"|"horizontal">
+    | null;
   theme?: UserTheme;
   tokenizer?: Tokenizer;
   hooks?: Hooks;
@@ -18,6 +20,11 @@ interface MarkdownProps extends Partial<ParserOptions> {
 ```
 
 FlatList note: `data` / `renderItem` / `horizontal` are omitted and managed internally.
+`ReactNode` item props remain accepted for backward compatibility with v8 and
+earlier. Pass `flatListProps={null}` to disable virtualization and render with
+`ScrollView` (useful for small docs). Blocks are keyed by content-derived
+`MarkdownBlock.id` (`src/lib/types.ts`), so only new/changed blocks re-parse
+when `value` changes (#451).
 
 ## Hook options (`src/hooks/useMarkdown.ts`)
 

--- a/src/hooks/useMarkdown.ts
+++ b/src/hooks/useMarkdown.ts
@@ -1,5 +1,5 @@
-import { type Hooks, lexer, type Tokenizer } from "marked";
-import { type ReactNode, useMemo } from "react";
+import { type Hooks, lexer, type Token, type Tokenizer } from "marked";
+import { type ReactNode, useMemo, useRef } from "react";
 import type { ColorSchemeName } from "react-native";
 import Parser from "../lib/Parser";
 import Renderer from "../lib/Renderer";
@@ -41,13 +41,106 @@ const useMarkdown = (
 		[options?.renderer, options?.baseUrl, styles, options?.selectable],
 	);
 
+	const prevTokensRef = useRef<Token[] | null>(null);
+	const prevElementsRef = useRef<ReactNode[] | null>(null);
+	const prevParserRef = useRef<Parser | null>(null);
+
 	const elements = useMemo(() => {
 		const tokens = lexer(value, {
 			gfm: true,
 			tokenizer: options?.tokenizer,
 			hooks: options?.hooks,
 		});
-		return parser.parse(tokens);
+
+		const prevTokens = prevTokensRef.current;
+		const prevElements = prevElementsRef.current;
+		const prevParser = prevParserRef.current;
+
+		// If parser changed (styles/renderer changed), re-parse fully
+		if (prevParser !== parser) {
+			const result = parser.parse(tokens);
+			prevTokensRef.current = tokens;
+			prevElementsRef.current = result;
+			prevParserRef.current = parser;
+			return result;
+		}
+
+		// If tokens identical to previous, return same array reference to bail out
+		if (prevTokens && prevElements && prevTokens.length === tokens.length) {
+			let allSame = true;
+			for (let i = 0; i < tokens.length; i++) {
+				const a = prevTokens[i] as Token & { raw?: string };
+				const b = tokens[i] as Token & { raw?: string };
+				if (a.raw !== b.raw || a.type !== b.type) {
+					allSame = false;
+					break;
+				}
+			}
+			if (allSame) {
+				return prevElements;
+			}
+		}
+
+		// Try prefix reuse for streaming appends
+		if (prevTokens && prevElements && tokens.length > prevTokens.length) {
+			let prefixMatches = true;
+			for (let i = 0; i < prevTokens.length; i++) {
+				const a = prevTokens[i] as Token & { raw?: string };
+				const b = tokens[i] as Token & { raw?: string };
+				if (a.raw !== b.raw || a.type !== b.type) {
+					prefixMatches = false;
+					break;
+				}
+			}
+			if (prefixMatches) {
+				const remainingTokens = tokens.slice(prevTokens.length);
+				const newElements = parser.parse(remainingTokens);
+				const result = [...prevElements, ...newElements];
+				prevTokensRef.current = tokens;
+				prevElementsRef.current = result;
+				return result;
+			}
+		}
+
+		// Per-index reuse for same-length edits (e.g., editing one paragraph)
+		if (prevTokens && prevElements && prevTokens.length === tokens.length) {
+			let hasReuse = false;
+			let needsParse = false;
+			const newElements: ReactNode[] = new Array(tokens.length);
+			for (let i = 0; i < tokens.length; i++) {
+				const a = prevTokens[i] as Token & { raw?: string };
+				const b = tokens[i] as Token & { raw?: string };
+				if (
+					a.raw === b.raw &&
+					a.type === b.type &&
+					prevElements[i] !== null &&
+					prevElements[i] !== undefined
+				) {
+					newElements[i] = prevElements[i] as ReactNode;
+					hasReuse = true;
+				} else {
+					needsParse = true;
+					newElements[i] = null as unknown as ReactNode;
+				}
+			}
+			if (hasReuse && needsParse) {
+				for (let i = 0; i < tokens.length; i++) {
+					if (newElements[i] === null) {
+						const parsed = parser.parse([tokens[i] as Token]);
+						newElements[i] = parsed[0] as ReactNode;
+					}
+				}
+				prevTokensRef.current = tokens;
+				prevElementsRef.current = newElements;
+				return newElements;
+			}
+		}
+
+		const result = parser.parse(tokens);
+		prevTokensRef.current = tokens;
+		prevElementsRef.current = result;
+		prevParserRef.current = parser;
+		return result;
 	}, [value, parser, options?.tokenizer, options?.hooks]);
 
 	return elements;

--- a/src/hooks/useMarkdown.ts
+++ b/src/hooks/useMarkdown.ts
@@ -1,6 +1,7 @@
 import { type Hooks, lexer, type Token, type Tokenizer } from "marked";
 import { type ReactNode, useMemo, useRef } from "react";
 import type { ColorSchemeName } from "react-native";
+import { isSameBlockToken } from "../lib/blockUtils";
 import Parser from "../lib/Parser";
 import Renderer from "../lib/Renderer";
 import type { RendererInterface } from "../lib/types";
@@ -50,7 +51,7 @@ const useMarkdown = (
 			gfm: true,
 			tokenizer: options?.tokenizer,
 			hooks: options?.hooks,
-		});
+		}).filter((t) => t.type !== "space");
 
 		const prevTokens = prevTokensRef.current;
 		const prevElements = prevElementsRef.current;
@@ -69,9 +70,9 @@ const useMarkdown = (
 		if (prevTokens && prevElements && prevTokens.length === tokens.length) {
 			let allSame = true;
 			for (let i = 0; i < tokens.length; i++) {
-				const a = prevTokens[i] as Token & { raw?: string };
-				const b = tokens[i] as Token & { raw?: string };
-				if (a.raw !== b.raw || a.type !== b.type) {
+				const a = prevTokens[i] as Token;
+				const b = tokens[i] as Token;
+				if (!isSameBlockToken(a, b)) {
 					allSame = false;
 					break;
 				}
@@ -85,9 +86,9 @@ const useMarkdown = (
 		if (prevTokens && prevElements && tokens.length > prevTokens.length) {
 			let prefixMatches = true;
 			for (let i = 0; i < prevTokens.length; i++) {
-				const a = prevTokens[i] as Token & { raw?: string };
-				const b = tokens[i] as Token & { raw?: string };
-				if (a.raw !== b.raw || a.type !== b.type) {
+				const a = prevTokens[i] as Token;
+				const b = tokens[i] as Token;
+				if (!isSameBlockToken(a, b)) {
 					prefixMatches = false;
 					break;
 				}
@@ -108,11 +109,10 @@ const useMarkdown = (
 			let needsParse = false;
 			const newElements: ReactNode[] = new Array(tokens.length);
 			for (let i = 0; i < tokens.length; i++) {
-				const a = prevTokens[i] as Token & { raw?: string };
-				const b = tokens[i] as Token & { raw?: string };
+				const a = prevTokens[i] as Token;
+				const b = tokens[i] as Token;
 				if (
-					a.raw === b.raw &&
-					a.type === b.type &&
+					isSameBlockToken(a, b) &&
 					prevElements[i] !== null &&
 					prevElements[i] !== undefined
 				) {

--- a/src/hooks/useMarkdownBlocks.ts
+++ b/src/hooks/useMarkdownBlocks.ts
@@ -1,0 +1,125 @@
+import { type Hooks, lexer, type Token, type Tokenizer } from "marked";
+import { useMemo, useRef } from "react";
+import type { ColorSchemeName } from "react-native";
+import Parser from "../lib/Parser";
+import Renderer from "../lib/Renderer";
+import type { MarkdownBlock, RendererInterface } from "../lib/types";
+import getStyles from "./../theme/styles";
+import type { MarkedStyles, UserTheme } from "./../theme/types";
+
+/**
+ * Simple deterministic hash for block id generation.
+ * Uses DJB2-like algorithm, returns hex string.
+ */
+function hashString(str: string): string {
+	let hash = 5381;
+	for (let i = 0; i < str.length; i++) {
+		hash = (hash * 33) ^ str.charCodeAt(i);
+	}
+	return (hash >>> 0).toString(16);
+}
+
+export interface UseMarkdownBlocksOptions {
+	colorScheme?: ColorSchemeName;
+	renderer?: RendererInterface;
+	theme?: UserTheme;
+	styles?: MarkedStyles;
+	baseUrl?: string;
+	tokenizer?: Tokenizer;
+	hooks?: Hooks;
+	selectable?: boolean;
+}
+
+const useMarkdownBlocks = (
+	value: string,
+	options?: UseMarkdownBlocksOptions,
+): { blocks: MarkdownBlock[]; parser: Parser } => {
+	const styles = useMemo(
+		() => getStyles(options?.styles, options?.colorScheme, options?.theme),
+		[options?.styles, options?.theme, options?.colorScheme],
+	);
+
+	const parser = useMemo(
+		() =>
+			new Parser({
+				styles,
+				baseUrl: options?.baseUrl,
+				renderer:
+					options?.renderer ??
+					new Renderer({ selectable: options?.selectable }),
+			}),
+		[options?.renderer, options?.baseUrl, styles, options?.selectable],
+	);
+
+	const tokens = useMemo(() => {
+		const rawTokens = lexer(value, {
+			gfm: true,
+			tokenizer: options?.tokenizer,
+			hooks: options?.hooks,
+		});
+		// Filter out non-renderable tokens (e.g., 'space') — mirrors Parser filtering where default returns null
+		return rawTokens.filter((t) => t.type !== "space");
+	}, [value, options?.tokenizer, options?.hooks]);
+
+	// Reuse previous blocks for stable references (prefix optimization for streaming)
+	const prevBlocksRef = useRef<MarkdownBlock[] | null>(null);
+	const prevParserRef = useRef<Parser | null>(null);
+
+	const blocks = useMemo(() => {
+		const prevBlocks = prevBlocksRef.current;
+		const prevParser = prevParserRef.current;
+		const parserChanged = prevParser !== parser;
+
+		// If parser changed (styles/theme/renderer changed), all blocks must be recreated
+		// because rendered output depends on styles/renderer.
+		if (parserChanged) {
+			const newBlocks: MarkdownBlock[] = tokens.map((token, index) => {
+				const raw = (token as { raw?: string }).raw ?? `${token.type}-${index}`;
+				const type = token.type;
+				const id = `${type}-${hashString(raw)}-${index}`;
+				return { id, token, raw, type };
+			});
+			prevBlocksRef.current = newBlocks;
+			prevParserRef.current = parser;
+			return newBlocks;
+		}
+
+		// Parser unchanged: try to reuse blocks where raw+type identical at same index
+		if (prevBlocks && prevBlocks.length === tokens.length) {
+			let allEqual = true;
+			for (let i = 0; i < tokens.length; i++) {
+				const t = tokens[i] as Token;
+				const prev = prevBlocks[i] as MarkdownBlock;
+				const raw = (t as { raw?: string }).raw ?? `${t.type}-${i}`;
+				if (prev.raw !== raw || prev.type !== t.type) {
+					allEqual = false;
+					break;
+				}
+			}
+			if (allEqual) {
+				// Return previous array reference to allow FlatList and memo to bail out completely
+				return prevBlocks;
+			}
+		}
+
+		const newBlocks: MarkdownBlock[] = tokens.map((token, index) => {
+			const raw = (token as { raw?: string }).raw ?? `${token.type}-${index}`;
+			const type = token.type;
+			const prev = prevBlocks?.[index];
+			if (prev && prev.raw === raw && prev.type === type) {
+				// Reuse previous block object (and thus its token reference) for memo bail-out
+				return prev;
+			}
+			const id = `${type}-${hashString(raw)}-${index}`;
+			return { id, token: token as Token, raw, type };
+		});
+
+		prevBlocksRef.current = newBlocks;
+		prevParserRef.current = parser;
+		return newBlocks;
+	}, [tokens, parser]);
+
+	return { blocks, parser };
+};
+
+export default useMarkdownBlocks;

--- a/src/hooks/useMarkdownBlocks.ts
+++ b/src/hooks/useMarkdownBlocks.ts
@@ -1,23 +1,16 @@
 import { type Hooks, lexer, type Token, type Tokenizer } from "marked";
 import { useMemo, useRef } from "react";
 import type { ColorSchemeName } from "react-native";
+import {
+	assignBlockIds,
+	getBlockRaw,
+	isSameBlockToken,
+} from "../lib/blockUtils";
 import Parser from "../lib/Parser";
 import Renderer from "../lib/Renderer";
 import type { MarkdownBlock, RendererInterface } from "../lib/types";
 import getStyles from "./../theme/styles";
 import type { MarkedStyles, UserTheme } from "./../theme/types";
-
-/**
- * Simple deterministic hash for block id generation.
- * Uses DJB2-like algorithm, returns hex string.
- */
-function hashString(str: string): string {
-	let hash = 5381;
-	for (let i = 0; i < str.length; i++) {
-		hash = (hash * 33) ^ str.charCodeAt(i);
-	}
-	return (hash >>> 0).toString(16);
-}
 
 export interface UseMarkdownBlocksOptions {
 	colorScheme?: ColorSchemeName;
@@ -69,49 +62,59 @@ const useMarkdownBlocks = (
 		const prevBlocks = prevBlocksRef.current;
 		const prevParser = prevParserRef.current;
 		const parserChanged = prevParser !== parser;
+		const ids = assignBlockIds(tokens);
 
 		// If parser changed (styles/theme/renderer changed), all blocks must be recreated
-		// because rendered output depends on styles/renderer.
+		// because rendered output depends on styles/renderer. Ids stay stable because
+		// they are content-derived.
 		if (parserChanged) {
 			const newBlocks: MarkdownBlock[] = tokens.map((token, index) => {
-				const raw = (token as { raw?: string }).raw ?? `${token.type}-${index}`;
-				const type = token.type;
-				const id = `${type}-${hashString(raw)}-${index}`;
-				return { id, token, raw, type };
+				const id = ids[index] as string;
+				return { id, token, raw: getBlockRaw(token, index), type: token.type };
 			});
 			prevBlocksRef.current = newBlocks;
 			prevParserRef.current = parser;
 			return newBlocks;
 		}
 
-		// Parser unchanged: try to reuse blocks where raw+type identical at same index
+		// Fast path: same blocks in the same order — return the previous array
+		// reference so FlatList and memo can bail out completely.
 		if (prevBlocks && prevBlocks.length === tokens.length) {
 			let allEqual = true;
 			for (let i = 0; i < tokens.length; i++) {
-				const t = tokens[i] as Token;
+				const token = tokens[i] as Token;
 				const prev = prevBlocks[i] as MarkdownBlock;
-				const raw = (t as { raw?: string }).raw ?? `${t.type}-${i}`;
-				if (prev.raw !== raw || prev.type !== t.type) {
+				if (prev.id !== ids[i] || !isSameBlockToken(prev.token, token)) {
 					allEqual = false;
 					break;
 				}
 			}
 			if (allEqual) {
-				// Return previous array reference to allow FlatList and memo to bail out completely
 				return prevBlocks;
 			}
 		}
 
+		// Content-keyed reuse: surviving blocks keep their object identity no
+		// matter where they moved (append, prepend, insert, delete, reorder),
+		// so memoized rows bail out. Only new/changed blocks are recreated.
+		const prevById = new Map<string, MarkdownBlock>();
+		if (prevBlocks) {
+			for (const block of prevBlocks) {
+				if (!prevById.has(block.id)) {
+					prevById.set(block.id, block);
+				}
+			}
+		}
+
 		const newBlocks: MarkdownBlock[] = tokens.map((token, index) => {
-			const raw = (token as { raw?: string }).raw ?? `${token.type}-${index}`;
-			const type = token.type;
-			const prev = prevBlocks?.[index];
-			if (prev && prev.raw === raw && prev.type === type) {
-				// Reuse previous block object (and thus its token reference) for memo bail-out
+			const id = ids[index] as string;
+			const prev = prevById.get(id);
+			if (prev && isSameBlockToken(prev.token, token)) {
+				// Consume so two new blocks never share one previous object.
+				prevById.delete(id);
 				return prev;
 			}
-			const id = `${type}-${hashString(raw)}-${index}`;
-			return { id, token: token as Token, raw, type };
+			return { id, token, raw: getBlockRaw(token, index), type: token.type };
 		});
 
 		prevBlocksRef.current = newBlocks;

--- a/src/hooks/useMarkdownWithComponents.tsx
+++ b/src/hooks/useMarkdownWithComponents.tsx
@@ -36,6 +36,11 @@ export function useMarkdownWithComponents(
 		customTokenizer.html = (src: string) => {
 			const token = originalHtml(src);
 			if (token && isReactComponentToken(token)) {
+				// Reuse existing id for stable keys across re-renders if raw already seen
+				const existing = map.get(token.raw);
+				if (existing) {
+					return token;
+				}
 				const id = `${token.componentName}-${componentCounter++}`;
 				map.set(token.raw, { token, id });
 			}

--- a/src/hooks/useMarkdownWithComponents.tsx
+++ b/src/hooks/useMarkdownWithComponents.tsx
@@ -36,9 +36,15 @@ export function useMarkdownWithComponents(
 		customTokenizer.html = (src: string) => {
 			const token = originalHtml(src);
 			if (token && isReactComponentToken(token)) {
-				// Reuse existing id for stable keys across re-renders if raw already seen
+				// Reuse the existing id for stable keys across re-renders when the
+				// same raw html is seen again, but store the fresh token so prop
+				// or children updates are not silently dropped.
+				// Note: identical components repeated in one document share one
+				// map entry (and therefore one id); repeated identical usage
+				// renders with duplicate keys.
 				const existing = map.get(token.raw);
 				if (existing) {
+					existing.token = token;
 					return token;
 				}
 				const id = `${token.componentName}-${componentCounter++}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,16 @@ import {
 	marked,
 } from "marked";
 import useMarkdown, { type useMarkdownHookOptions } from "./hooks/useMarkdown";
+import useMarkdownBlocks, {
+	type UseMarkdownBlocksOptions,
+} from "./hooks/useMarkdownBlocks";
 import useMarkdownWithComponents from "./hooks/useMarkdownWithComponents";
 import Markdown from "./lib/Markdown";
 import type { ReactComponentRegistry } from "./lib/ReactComponentRegistry";
 import { ReactComponentRegistryProvider } from "./lib/ReactComponentRegistry";
 import Renderer, { type RendererOptions } from "./lib/Renderer";
 import type {
+	MarkdownBlock,
 	MarkdownProps,
 	ParserOptions,
 	RendererInterface,
@@ -20,6 +24,7 @@ import type { MarkedStyles } from "./theme/types";
 const MarkedLexer = marked.lexer;
 
 export type {
+	MarkdownBlock,
 	MarkdownProps,
 	MarkedStyles,
 	ParserOptions,
@@ -28,6 +33,7 @@ export type {
 	RendererOptions,
 	Token,
 	Tokens,
+	UseMarkdownBlocksOptions,
 	useMarkdownHookOptions,
 };
 
@@ -38,6 +44,7 @@ export {
 	ReactComponentRegistryProvider,
 	Renderer,
 	useMarkdown,
+	useMarkdownBlocks,
 	useMarkdownWithComponents,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import useMarkdownBlocks, {
 } from "./hooks/useMarkdownBlocks";
 import useMarkdownWithComponents from "./hooks/useMarkdownWithComponents";
 import Markdown from "./lib/Markdown";
+import MarkdownBlockView from "./lib/MarkdownBlock";
 import type { ReactComponentRegistry } from "./lib/ReactComponentRegistry";
 import { ReactComponentRegistryProvider } from "./lib/ReactComponentRegistry";
 import Renderer, { type RendererOptions } from "./lib/Renderer";
@@ -38,6 +39,7 @@ export type {
 };
 
 export {
+	MarkdownBlockView,
 	MarkedHooks,
 	MarkedLexer,
 	MarkedTokenizer,

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -1,7 +1,8 @@
-import React, { type ReactElement, type ReactNode, useCallback } from "react";
-import { FlatList, useColorScheme } from "react-native";
-import useMarkdown from "../hooks/useMarkdown";
-import type { MarkdownProps } from "./types";
+import React, { useCallback } from "react";
+import { FlatList, ScrollView, useColorScheme, View } from "react-native";
+import useMarkdownBlocks from "../hooks/useMarkdownBlocks";
+import MarkdownBlockView from "./MarkdownBlock";
+import type { MarkdownBlock, MarkdownProps } from "./types";
 
 const Markdown = ({
 	value,
@@ -16,7 +17,7 @@ const Markdown = ({
 }: MarkdownProps) => {
 	const colorScheme = useColorScheme();
 
-	const rnElements = useMarkdown(value, {
+	const { blocks, parser } = useMarkdownBlocks(value, {
 		theme,
 		baseUrl,
 		renderer,
@@ -27,14 +28,41 @@ const Markdown = ({
 		selectable,
 	});
 
-	const renderItem = useCallback(({ item }: { item: ReactNode }) => {
-		return item as ReactElement;
-	}, []);
-
-	const keyExtractor = useCallback(
-		(_: ReactNode, index: number) => index.toString(),
-		[],
+	const renderItem = useCallback(
+		({ item }: { item: MarkdownBlock }) => {
+			return (
+				<MarkdownBlockView
+					token={item.token}
+					parser={parser}
+					blockId={item.id}
+				/>
+			);
+		},
+		[parser],
 	);
+
+	const keyExtractor = useCallback((item: MarkdownBlock) => item.id, []);
+
+	const backgroundStyle = {
+		backgroundColor: colorScheme === "light" ? "#ffffff" : "#000000",
+	};
+
+	// Opt-out of virtualization: when flatListProps is explicitly null, render with ScrollView
+	if (flatListProps === null) {
+		return (
+			<ScrollView style={backgroundStyle}>
+				{blocks.map((block) => (
+					<View key={block.id}>
+						<MarkdownBlockView
+							token={block.token}
+							parser={parser}
+							blockId={block.id}
+						/>
+					</View>
+				))}
+			</ScrollView>
+		);
+	}
 
 	return (
 		<FlatList
@@ -42,11 +70,9 @@ const Markdown = ({
 			keyExtractor={keyExtractor}
 			maxToRenderPerBatch={8}
 			initialNumToRender={8}
-			style={{
-				backgroundColor: colorScheme === "light" ? "#ffffff" : "#000000",
-			}}
+			style={backgroundStyle}
 			{...flatListProps}
-			data={rnElements}
+			data={blocks}
 			renderItem={renderItem}
 		/>
 	);

--- a/src/lib/Markdown.tsx
+++ b/src/lib/Markdown.tsx
@@ -1,5 +1,10 @@
-import React, { useCallback } from "react";
-import { FlatList, ScrollView, useColorScheme, View } from "react-native";
+import React, { useCallback, useMemo } from "react";
+import {
+	FlatList,
+	type FlatListProps,
+	ScrollView,
+	useColorScheme,
+} from "react-native";
 import useMarkdownBlocks from "../hooks/useMarkdownBlocks";
 import MarkdownBlockView from "./MarkdownBlock";
 import type { MarkdownBlock, MarkdownProps } from "./types";
@@ -43,26 +48,36 @@ const Markdown = ({
 
 	const keyExtractor = useCallback((item: MarkdownBlock) => item.id, []);
 
-	const backgroundStyle = {
-		backgroundColor: colorScheme === "light" ? "#ffffff" : "#000000",
-	};
+	const backgroundStyle = useMemo(
+		() => ({
+			backgroundColor: colorScheme === "light" ? "#ffffff" : "#000000",
+		}),
+		[colorScheme],
+	);
 
 	// Opt-out of virtualization: when flatListProps is explicitly null, render with ScrollView
 	if (flatListProps === null) {
 		return (
 			<ScrollView style={backgroundStyle}>
 				{blocks.map((block) => (
-					<View key={block.id}>
-						<MarkdownBlockView
-							token={block.token}
-							parser={parser}
-							blockId={block.id}
-						/>
-					</View>
+					<MarkdownBlockView
+						key={block.id}
+						token={block.token}
+						parser={parser}
+						blockId={block.id}
+					/>
 				))}
 			</ScrollView>
 		);
 	}
+
+	// `ReactNode`-flavored props are accepted for backward compatibility (see
+	// `MarkdownProps.flatListProps`); at runtime the items are always
+	// `MarkdownBlock`s and the remaining list props don't depend on the item
+	// type, so narrowing here is safe.
+	const restListProps = flatListProps as
+		| Omit<FlatListProps<MarkdownBlock>, "data" | "renderItem" | "horizontal">
+		| undefined;
 
 	return (
 		<FlatList
@@ -71,7 +86,7 @@ const Markdown = ({
 			maxToRenderPerBatch={8}
 			initialNumToRender={8}
 			style={backgroundStyle}
-			{...flatListProps}
+			{...restListProps}
 			data={blocks}
 			renderItem={renderItem}
 		/>

--- a/src/lib/MarkdownBlock.tsx
+++ b/src/lib/MarkdownBlock.tsx
@@ -1,0 +1,41 @@
+import type { Token } from "marked";
+import { memo, type ReactElement, type ReactNode, useMemo } from "react";
+import type Parser from "./Parser";
+
+type MarkdownBlockProps = {
+	token: Token;
+	parser: Parser;
+	blockId: string;
+};
+
+const MarkdownBlockComponent = ({
+	token,
+	parser,
+}: MarkdownBlockProps): ReactNode => {
+	const element = useMemo(() => {
+		const result = parser.parse([token]);
+		return (result[0] ?? null) as ReactNode;
+	}, [token, parser]);
+
+	if (!element) return null;
+	return element as ReactElement;
+};
+
+const areEqual = (
+	prev: MarkdownBlockProps,
+	next: MarkdownBlockProps,
+): boolean => {
+	if (prev.blockId !== next.blockId) return false;
+	if (prev.parser !== next.parser) return false;
+	// Compare token raw and type to avoid re-render when content unchanged
+	// Token objects are new each lexer call, so compare by value
+	const prevRaw = (prev.token as { raw?: string }).raw ?? "";
+	const nextRaw = (next.token as { raw?: string }).raw ?? "";
+	if (prevRaw !== nextRaw) return false;
+	if (prev.token.type !== next.token.type) return false;
+	return true;
+};
+
+const MarkdownBlock = memo(MarkdownBlockComponent, areEqual);
+
+export default MarkdownBlock;

--- a/src/lib/MarkdownBlock.tsx
+++ b/src/lib/MarkdownBlock.tsx
@@ -1,5 +1,6 @@
 import type { Token } from "marked";
 import { memo, type ReactElement, type ReactNode, useMemo } from "react";
+import { isSameBlockToken } from "./blockUtils";
 import type Parser from "./Parser";
 
 type MarkdownBlockProps = {
@@ -27,13 +28,9 @@ const areEqual = (
 ): boolean => {
 	if (prev.blockId !== next.blockId) return false;
 	if (prev.parser !== next.parser) return false;
-	// Compare token raw and type to avoid re-render when content unchanged
-	// Token objects are new each lexer call, so compare by value
-	const prevRaw = (prev.token as { raw?: string }).raw ?? "";
-	const nextRaw = (next.token as { raw?: string }).raw ?? "";
-	if (prevRaw !== nextRaw) return false;
-	if (prev.token.type !== next.token.type) return false;
-	return true;
+	// Compare token value (not identity): token objects are recreated on
+	// every lexer call, so identity comparison would never bail out.
+	return isSameBlockToken(prev.token, next.token);
 };
 
 const MarkdownBlock = memo(MarkdownBlockComponent, areEqual);

--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -37,6 +37,10 @@ class Renderer implements RendererInterface {
 		this.selectable = options?.selectable ?? true;
 	}
 
+	resetKeys(): void {
+		this.slugger = new Slugger();
+	}
+
 	paragraph(children: ReactNode[], styles?: ViewStyle): ReactNode {
 		return this.getViewNode(children, styles);
 	}

--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -37,10 +37,6 @@ class Renderer implements RendererInterface {
 		this.selectable = options?.selectable ?? true;
 	}
 
-	resetKeys(): void {
-		this.slugger = new Slugger();
-	}
-
 	paragraph(children: ReactNode[], styles?: ViewStyle): ReactNode {
 		return this.getViewNode(children, styles);
 	}

--- a/src/lib/__tests__/FlatListRerender.spec.tsx
+++ b/src/lib/__tests__/FlatListRerender.spec.tsx
@@ -1,0 +1,65 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import Markdown from "../Markdown";
+import Renderer from "../Renderer";
+
+describe("Prevent FlatList item re-rendering #451", () => {
+	it("reuses existing blocks when appending content", () => {
+		const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+		const headingSpy = jest.spyOn(Renderer.prototype, "heading");
+
+		const { rerender } = render(<Markdown value={"# Hello\n\nParagraph 1"} />);
+
+		// Reset spies to count only rerender calls
+		paragraphSpy.mockClear();
+		headingSpy.mockClear();
+
+		rerender(<Markdown value={"# Hello\n\nParagraph 1\n\nParagraph 2"} />);
+
+		// Only new paragraph should trigger paragraph renderer, heading should not re-render
+		expect(paragraphSpy).toHaveBeenCalledTimes(1);
+		expect(headingSpy).not.toHaveBeenCalled();
+
+		paragraphSpy.mockRestore();
+		headingSpy.mockRestore();
+	});
+
+	it("does not re-render unchanged blocks when editing middle block", () => {
+		const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+
+		const { rerender } = render(
+			<Markdown value={"Paragraph 1\n\nParagraph 2\n\nParagraph 3"} />,
+		);
+		paragraphSpy.mockClear();
+
+		rerender(
+			<Markdown value={"Paragraph 1\n\nEdited Paragraph 2\n\nParagraph 3"} />,
+		);
+
+		// Only edited block should re-render (at least 1 call), not all 3
+		// With per-index reuse, 1 paragraph should be re-parsed
+		expect(paragraphSpy.mock.calls.length).toBe(1);
+
+		paragraphSpy.mockRestore();
+	});
+
+	it("supports disableVirtualization via flatListProps=null", () => {
+		const { toJSON } = render(
+			<Markdown value={"# Hello\n\nWorld"} flatListProps={null} />,
+		);
+		const tree = toJSON();
+		expect(tree).toBeTruthy();
+		// Should render via ScrollView, not FlatList
+		// FlatList renders as RCTScrollView with VirtualizedList data prop; ScrollView renders simpler
+		expect(JSON.stringify(tree)).not.toContain("VirtualizedList");
+	});
+
+	it("uses stable keys based on content hash not index", () => {
+		const { rerender, toJSON } = render(<Markdown value={"A\n\nB\n\nC"} />);
+		const firstTree = JSON.stringify(toJSON());
+		rerender(<Markdown value={"A\n\nB\n\nC"} />);
+		const secondTree = JSON.stringify(toJSON());
+		// Trees should be structurally identical if keys stable
+		expect(firstTree).toBe(secondTree);
+	});
+});

--- a/src/lib/__tests__/FlatListRerender.spec.tsx
+++ b/src/lib/__tests__/FlatListRerender.spec.tsx
@@ -1,7 +1,36 @@
 import { render } from "@testing-library/react-native";
-import React from "react";
+import type { Hooks } from "marked";
+import React, { type ReactNode } from "react";
+import useMarkdown from "../../hooks/useMarkdown";
+import useMarkdownBlocks from "../../hooks/useMarkdownBlocks";
 import Markdown from "../Markdown";
 import Renderer from "../Renderer";
+
+const BlockIdsProbe = ({
+	value,
+	onBlocks,
+}: {
+	value: string;
+	onBlocks: (ids: string[]) => void;
+}) => {
+	const { blocks } = useMarkdownBlocks(value);
+	onBlocks(blocks.map((block) => block.id));
+	return null;
+};
+
+const ElementsProbe = ({
+	value,
+	hooks,
+	onElements,
+}: {
+	value: string;
+	hooks?: Hooks;
+	onElements: (elements: ReactNode[]) => void;
+}) => {
+	const elements = useMarkdown(value, { hooks });
+	onElements(elements);
+	return null;
+};
 
 describe("Prevent FlatList item re-rendering #451", () => {
 	it("reuses existing blocks when appending content", () => {
@@ -61,5 +90,151 @@ describe("Prevent FlatList item re-rendering #451", () => {
 		const secondTree = JSON.stringify(toJSON());
 		// Trees should be structurally identical if keys stable
 		expect(firstTree).toBe(secondTree);
+	});
+
+	it("reuses surviving blocks when prepending content", () => {
+		const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+
+		const { rerender } = render(
+			<Markdown value={"Paragraph B\n\nParagraph C"} />,
+		);
+		paragraphSpy.mockClear();
+
+		rerender(<Markdown value={"Paragraph A\n\nParagraph B\n\nParagraph C"} />);
+
+		// Only the new first block re-parses; B and C keep content-derived ids.
+		expect(paragraphSpy).toHaveBeenCalledTimes(1);
+
+		paragraphSpy.mockRestore();
+	});
+
+	it("reuses surviving blocks when inserting in the middle", () => {
+		const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+
+		const { rerender } = render(
+			<Markdown value={"Paragraph A\n\nParagraph C"} />,
+		);
+		paragraphSpy.mockClear();
+
+		rerender(<Markdown value={"Paragraph A\n\nParagraph B\n\nParagraph C"} />);
+
+		expect(paragraphSpy).toHaveBeenCalledTimes(1);
+
+		paragraphSpy.mockRestore();
+	});
+
+	it("does not re-parse anything when deleting a block", () => {
+		const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+
+		const { rerender } = render(
+			<Markdown value={"Paragraph A\n\nParagraph B\n\nParagraph C"} />,
+		);
+		paragraphSpy.mockClear();
+
+		rerender(<Markdown value={"Paragraph A\n\nParagraph C"} />);
+
+		// A and C are reused by content id; nothing new to parse.
+		expect(paragraphSpy).not.toHaveBeenCalled();
+
+		paragraphSpy.mockRestore();
+	});
+
+	it("keeps stable ids for surviving blocks across prepend", () => {
+		const seen: string[][] = [];
+		const onBlocks = (ids: string[]) => {
+			seen.push(ids);
+		};
+
+		const { rerender } = render(
+			<BlockIdsProbe value={"B\n\nC"} onBlocks={onBlocks} />,
+		);
+		rerender(<BlockIdsProbe value={"A\n\nB\n\nC"} onBlocks={onBlocks} />);
+
+		expect(seen).toHaveLength(2);
+		// B and C keep their ids even though their indices shifted.
+		expect(seen[1]?.slice(1)).toEqual(seen[0]);
+		// All ids unique.
+		expect(new Set(seen[1]).size).toBe(seen[1]?.length);
+	});
+
+	it("gives unique, stable ids to duplicate blocks", () => {
+		const seen: string[][] = [];
+		const onBlocks = (ids: string[]) => {
+			seen.push(ids);
+		};
+
+		const { rerender } = render(
+			<BlockIdsProbe value={"Same\n\nSame"} onBlocks={onBlocks} />,
+		);
+		rerender(<BlockIdsProbe value={"Same\n\nSame"} onBlocks={onBlocks} />);
+
+		expect(seen[0]).toHaveLength(2);
+		expect(new Set(seen[0]).size).toBe(2);
+		expect(seen[1]).toEqual(seen[0]);
+	});
+
+	describe("useMarkdown caching", () => {
+		it("bails out when lexer re-runs with identical tokens", () => {
+			const seen: ReactNode[][] = [];
+			const onElements = (elements: ReactNode[]) => {
+				seen.push(elements);
+			};
+
+			const { rerender } = render(
+				<ElementsProbe
+					value={"Hello"}
+					onElements={onElements}
+					hooks={{} as Hooks}
+				/>,
+			);
+			// New hooks identity forces the elements memo to recompute, but the
+			// tokens are identical so the previous array is returned as-is.
+			rerender(
+				<ElementsProbe
+					value={"Hello"}
+					onElements={onElements}
+					hooks={{} as Hooks}
+				/>,
+			);
+
+			expect(seen).toHaveLength(2);
+			expect(seen[1]).toBe(seen[0]);
+		});
+
+		it("only parses appended blocks when value grows", () => {
+			const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+			const onElements = () => {};
+
+			const { rerender } = render(
+				<ElementsProbe value={"Para 1"} onElements={onElements} />,
+			);
+			paragraphSpy.mockClear();
+
+			rerender(
+				<ElementsProbe value={"Para 1\n\nPara 2"} onElements={onElements} />,
+			);
+
+			expect(paragraphSpy).toHaveBeenCalledTimes(1);
+
+			paragraphSpy.mockRestore();
+		});
+
+		it("only re-parses the edited block for same-length edits", () => {
+			const paragraphSpy = jest.spyOn(Renderer.prototype, "paragraph");
+			const onElements = () => {};
+
+			const { rerender } = render(
+				<ElementsProbe value={"Para 1\n\nPara 2"} onElements={onElements} />,
+			);
+			paragraphSpy.mockClear();
+
+			rerender(
+				<ElementsProbe value={"Para 1\n\nEdited"} onElements={onElements} />,
+			);
+
+			expect(paragraphSpy).toHaveBeenCalledTimes(1);
+
+			paragraphSpy.mockRestore();
+		});
 	});
 });

--- a/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
@@ -4,42 +4,31 @@ exports[`Blockquotes Blockquote 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderLeftColor": "#d0d7de",
-            "borderLeftWidth": 4,
-            "opacity": 0.8,
-            "paddingLeft": 16,
-          }
-        }
-      >
-        <View
-          style={
+      {
+        "id": "blockquote-73ffc6f0-0",
+        "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.",
+        "token": {
+          "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.",
+          "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+          "tokens": [
             {
-              "paddingVertical": 8,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            <Text
-              selectable={true}
-              style={
+              "raw": "Dorothy followed her through many of the beautiful rooms in her castle.",
+              "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Dorothy followed her through many of the beautiful rooms in her castle.
-            </Text>
-          </Text>
-        </View>
-      </View>,
+                  "escaped": false,
+                  "raw": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "blockquote",
+        },
+        "type": "blockquote",
+      },
     ]
   }
   getItem={[Function]}
@@ -116,67 +105,56 @@ exports[`Blockquotes Blockquotes with Multiple Paragraphs 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderLeftColor": "#d0d7de",
-            "borderLeftWidth": 4,
-            "opacity": 0.8,
-            "paddingLeft": 16,
-          }
-        }
-      >
-        <View
-          style={
+      {
+        "id": "blockquote-77de6fb9-0",
+        "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
+>
+> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+        "token": {
+          "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
+>
+> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+          "text": "Dorothy followed her through many of the beautiful rooms in her castle.
+
+The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+          "tokens": [
             {
-              "paddingVertical": 8,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            <Text
-              selectable={true}
-              style={
+              "raw": "Dorothy followed her through many of the beautiful rooms in her castle.",
+              "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Dorothy followed her through many of the beautiful rooms in her castle.
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
+                  "escaped": false,
+                  "raw": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
             {
-              "paddingVertical": 8,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            <Text
-              selectable={true}
-              style={
+              "raw": "
+
+",
+              "type": "space",
+            },
+            {
+              "raw": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+              "text": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.
-            </Text>
-          </Text>
-        </View>
-      </View>,
+                  "escaped": false,
+                  "raw": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                  "text": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "blockquote",
+        },
+        "type": "blockquote",
+      },
     ]
   }
   getItem={[Function]}
@@ -278,179 +256,165 @@ exports[`Blockquotes Blockquotes with Other Elements 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderLeftColor": "#d0d7de",
-            "borderLeftWidth": 4,
-            "opacity": 0.8,
-            "paddingLeft": 16,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={
+      {
+        "id": "blockquote-78354748-0",
+        "raw": "> #### The quarterly results look great!
+>
+> - Revenue was off the chart.
+> - Profits were higher than ever.
+>
+>  *Everything* is going according to **plan**.",
+        "token": {
+          "raw": "> #### The quarterly results look great!
+>
+> - Revenue was off the chart.
+> - Profits were higher than ever.
+>
+>  *Everything* is going according to **plan**.",
+          "text": "#### The quarterly results look great!
+
+- Revenue was off the chart.
+- Profits were higher than ever.
+
+ *Everything* is going according to **plan**.",
+          "tokens": [
             {
-              "color": "#333333",
-              "fontSize": 22,
-              "fontWeight": "500",
-              "lineHeight": 28,
-              "marginVertical": 4,
-            }
-          }
-        >
-          The quarterly results look great!
-        </Text>
-        <Memo(MDList)
-          li={
-            [
-              <View
-                style={
-                  {
-                    "color": "#333333",
-                    "flexShrink": 1,
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Revenue was off the chart.
-                  </Text>
-                </Text>
-              </View>,
-              <View
-                style={
-                  {
-                    "color": "#333333",
-                    "flexShrink": 1,
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Profits were higher than ever.
-                  </Text>
-                </Text>
-              </View>,
-            ]
-          }
-          listStyle={{}}
-          ordered={false}
-          startIndex={1}
-          textStyle={
+              "depth": 4,
+              "raw": "#### The quarterly results look great!",
+              "text": "The quarterly results look great!",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "The quarterly results look great!",
+                  "text": "The quarterly results look great!",
+                  "type": "text",
+                },
+              ],
+              "type": "heading",
+            },
             {
-              "color": "#333333",
-              "flexShrink": 1,
-              "fontSize": 16,
-              "lineHeight": 24,
-            }
-          }
-        />
-        <View
-          style={
+              "raw": "
+
+",
+              "type": "space",
+            },
             {
-              "paddingVertical": 8,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            <Text
-              selectable={true}
-              style={
+              "items": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-               
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "loose": false,
+                  "raw": "- Revenue was off the chart.
+",
+                  "task": false,
+                  "text": "Revenue was off the chart.",
+                  "tokens": [
+                    {
+                      "raw": "Revenue was off the chart.",
+                      "text": "Revenue was off the chart.",
+                      "tokens": [
+                        {
+                          "escaped": false,
+                          "raw": "Revenue was off the chart.",
+                          "text": "Revenue was off the chart.",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "text",
+                    },
+                  ],
+                  "type": "list_item",
+                },
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Everything
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "loose": false,
+                  "raw": "- Profits were higher than ever.",
+                  "task": false,
+                  "text": "Profits were higher than ever.",
+                  "tokens": [
+                    {
+                      "raw": "Profits were higher than ever.",
+                      "text": "Profits were higher than ever.",
+                      "tokens": [
+                        {
+                          "escaped": false,
+                          "raw": "Profits were higher than ever.",
+                          "text": "Profits were higher than ever.",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "text",
+                    },
+                  ],
+                  "type": "list_item",
+                },
+              ],
+              "loose": false,
+              "ordered": false,
+              "raw": "- Revenue was off the chart.
+- Profits were higher than ever.",
+              "start": "",
+              "type": "list",
+            },
+            {
+              "raw": "
+
+",
+              "type": "space",
+            },
+            {
+              "raw": " *Everything* is going according to **plan**.",
+              "text": " *Everything* is going according to **plan**.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-               is going according to 
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "escaped": false,
+                  "raw": " ",
+                  "text": " ",
+                  "type": "text",
+                },
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              plan
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "raw": "*Everything*",
+                  "text": "Everything",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Everything",
+                      "text": "Everything",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "em",
+                },
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              .
-            </Text>
-          </Text>
-        </View>
-      </View>,
+                  "escaped": false,
+                  "raw": " is going according to ",
+                  "text": " is going according to ",
+                  "type": "text",
+                },
+                {
+                  "raw": "**plan**",
+                  "text": "plan",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "plan",
+                      "text": "plan",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "strong",
+                },
+                {
+                  "escaped": false,
+                  "raw": ".",
+                  "text": ".",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "blockquote",
+        },
+        "type": "blockquote",
+      },
     ]
   }
   getItem={[Function]}
@@ -725,89 +689,67 @@ exports[`Blockquotes Nested Blockquotes 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderLeftColor": "#d0d7de",
-            "borderLeftWidth": 4,
-            "opacity": 0.8,
-            "paddingLeft": 16,
-          }
-        }
-      >
-        <View
-          style={
+      {
+        "id": "blockquote-730d4404-0",
+        "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
+>",
+        "token": {
+          "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
+>",
+          "text": "Dorothy followed her through many of the beautiful rooms in her castle.
+",
+          "tokens": [
             {
-              "paddingVertical": 8,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            <Text
-              selectable={true}
-              style={
+              "raw": "Dorothy followed her through many of the beautiful rooms in her castle.
+",
+              "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Dorothy followed her through many of the beautiful rooms in her castle.
-            </Text>
-          </Text>
-        </View>
-      </View>,
-      <View
-        style={
-          {
-            "borderLeftColor": "#d0d7de",
-            "borderLeftWidth": 4,
-            "opacity": 0.8,
-            "paddingLeft": 16,
-          }
-        }
-      >
-        <View
-          style={
+                  "escaped": false,
+                  "raw": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "text": "Dorothy followed her through many of the beautiful rooms in her castle.",
+                  "type": "text",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ],
+          "type": "blockquote",
+        },
+        "type": "blockquote",
+      },
+      {
+        "id": "blockquote-c09d6c-1",
+        "raw": ">> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+        "token": {
+          "raw": ">> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+          "text": "> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+          "tokens": [
             {
-              "borderLeftColor": "#d0d7de",
-              "borderLeftWidth": 4,
-              "opacity": 0.8,
-              "paddingLeft": 16,
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "paddingVertical": 8,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={{}}
-            >
-              <Text
-                selectable={true}
-                style={
-                  {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.
-              </Text>
-            </Text>
-          </View>
-        </View>
-      </View>,
+              "raw": "> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+              "text": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+              "tokens": [
+                {
+                  "raw": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                  "text": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                      "text": "The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "blockquote",
+            },
+          ],
+          "type": "blockquote",
+        },
+        "type": "blockquote",
+      },
     ]
   }
   getItem={[Function]}
@@ -937,35 +879,27 @@ exports[`Code Code Blocks (backtick) 1`] = `
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-              }
-            }
-          >
-                  &lt;head&gt;
-      &lt;/head&gt;
-    &lt;/html&gt;
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-5e6a3f25-0",
+        "raw": "\`\`\`<html>
+      <head>
+      </head>
+    </html>
+\`\`\`",
+        "token": {
+          "lang": "<html>",
+          "raw": "\`\`\`<html>
+      <head>
+      </head>
+    </html>
+\`\`\`",
+          "text": "      <head>
+      </head>
+    </html>",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1037,35 +971,25 @@ exports[`Code Code Blocks (backtick), no ending backtick 1`] = `
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-              }
-            }
-          >
-                  &lt;head&gt;
-      &lt;/head&gt;
-    &lt;/html&gt;
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-552af7cf-0",
+        "raw": "\`\`\`<html>
+      <head>
+      </head>
+    </html>",
+        "token": {
+          "lang": "<html>",
+          "raw": "\`\`\`<html>
+      <head>
+      </head>
+    </html>",
+          "text": "      <head>
+      </head>
+    </html>",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1137,36 +1061,26 @@ exports[`Code Code Blocks 1`] = `
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-              }
-            }
-          >
-            &lt;html&gt;
-  &lt;head&gt;
-  &lt;/head&gt;
-&lt;/html&gt;
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-c5f1090f-0",
+        "raw": "    <html>
+      <head>
+      </head>
+    </html>",
+        "token": {
+          "codeBlockStyle": "indented",
+          "raw": "    <html>
+      <head>
+      </head>
+    </html>",
+          "text": "<html>
+  <head>
+  </head>
+</html>",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1239,58 +1153,35 @@ exports[`Code Code Span 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            At the command prompt, type 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "backgroundColor": "#f6f8fa",
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "fontWeight": "300",
-                "lineHeight": 24,
-              }
-            }
-          >
-            'nano'
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-23f09ebe-0",
+        "raw": "At the command prompt, type \`'nano'\`.",
+        "token": {
+          "raw": "At the command prompt, type \`'nano'\`.",
+          "text": "At the command prompt, type \`'nano'\`.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "At the command prompt, type ",
+              "text": "At the command prompt, type ",
+              "type": "text",
+            },
+            {
+              "raw": "\`'nano'\`",
+              "text": "'nano'",
+              "type": "codespan",
+            },
+            {
+              "escaped": false,
+              "raw": ".",
+              "text": ".",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1383,56 +1274,43 @@ exports[`Emphasis Bold 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Love 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "lineHeight": 24,
-              }
-            }
-          >
-            is
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             bold
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-5111aa8a-0",
+        "raw": "Love **is** bold",
+        "token": {
+          "raw": "Love **is** bold",
+          "text": "Love **is** bold",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Love ",
+              "text": "Love ",
+              "type": "text",
+            },
+            {
+              "raw": "**is**",
+              "text": "is",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "is",
+                  "text": "is",
+                  "type": "text",
+                },
+              ],
+              "type": "strong",
+            },
+            {
+              "escaped": false,
+              "raw": " bold",
+              "text": " bold",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1523,69 +1401,50 @@ exports[`Emphasis Bold and Italic 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            This is really 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={
+      {
+        "id": "paragraph-ffa0181b-0",
+        "raw": "This is really ***very*** important text.",
+        "token": {
+          "raw": "This is really ***very*** important text.",
+          "text": "This is really ***very*** important text.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "This is really ",
+              "text": "This is really ",
+              "type": "text",
+            },
+            {
+              "raw": "***very***",
+              "text": "**very**",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              very
-            </Text>
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             important text.
-          </Text>
-        </Text>
-      </View>,
+                  "raw": "**very**",
+                  "text": "very",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "very",
+                      "text": "very",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "strong",
+                },
+              ],
+              "type": "em",
+            },
+            {
+              "escaped": false,
+              "raw": " important text.",
+              "text": " important text.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1689,56 +1548,43 @@ exports[`Emphasis Italic 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            A 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            cat
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             meow
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-1bcd6022-0",
+        "raw": "A *cat* meow",
+        "token": {
+          "raw": "A *cat* meow",
+          "text": "A *cat* meow",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "A ",
+              "text": "A ",
+              "type": "text",
+            },
+            {
+              "raw": "*cat*",
+              "text": "cat",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "cat",
+                  "text": "cat",
+                  "type": "text",
+                },
+              ],
+              "type": "em",
+            },
+            {
+              "escaped": false,
+              "raw": " meow",
+              "text": " meow",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1829,57 +1675,43 @@ exports[`Emphasis Strikethrough 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            A 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-                "textDecorationLine": "line-through",
-                "textDecorationStyle": "solid",
-              }
-            }
-          >
-            cat
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             meow
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-471a58a2-0",
+        "raw": "A ~~cat~~ meow",
+        "token": {
+          "raw": "A ~~cat~~ meow",
+          "text": "A ~~cat~~ meow",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "A ",
+              "text": "A ",
+              "type": "text",
+            },
+            {
+              "raw": "~~cat~~",
+              "text": "cat",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "cat",
+                  "text": "cat",
+                  "type": "text",
+                },
+              ],
+              "type": "del",
+            },
+            {
+              "escaped": false,
+              "raw": " meow",
+              "text": " meow",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1971,43 +1803,29 @@ exports[`Escaping Characters Render 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            *
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             Without the backslash, this would be a bullet in an unordered list.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-b5140f57-0",
+        "raw": "\\* Without the backslash, this would be a bullet in an unordered list.",
+        "token": {
+          "raw": "\\* Without the backslash, this would be a bullet in an unordered list.",
+          "text": "\\* Without the backslash, this would be a bullet in an unordered list.",
+          "tokens": [
+            {
+              "raw": "\\*",
+              "text": "*",
+              "type": "escape",
+            },
+            {
+              "escaped": false,
+              "raw": " Without the backslash, this would be a bullet in an unordered list.",
+              "text": " Without the backslash, this would be a bullet in an unordered list.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -2085,104 +1903,71 @@ exports[`HTML Render 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            This 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "lineHeight": 24,
-              }
-            }
-          >
-            word
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             is bold. This 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            &lt;em&gt;
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            word
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            &lt;/em&gt;
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             is italic.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-6851ed15-0",
+        "raw": "This **word** is bold. This <em>word</em> is italic.",
+        "token": {
+          "raw": "This **word** is bold. This <em>word</em> is italic.",
+          "text": "This **word** is bold. This <em>word</em> is italic.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "This ",
+              "text": "This ",
+              "type": "text",
+            },
+            {
+              "raw": "**word**",
+              "text": "word",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "word",
+                  "text": "word",
+                  "type": "text",
+                },
+              ],
+              "type": "strong",
+            },
+            {
+              "escaped": false,
+              "raw": " is bold. This ",
+              "text": " is bold. This ",
+              "type": "text",
+            },
+            {
+              "block": false,
+              "inLink": false,
+              "inRawBlock": false,
+              "raw": "<em>",
+              "text": "<em>",
+              "type": "html",
+            },
+            {
+              "escaped": false,
+              "raw": "word",
+              "text": "word",
+              "type": "text",
+            },
+            {
+              "block": false,
+              "inLink": false,
+              "inRawBlock": false,
+              "raw": "</em>",
+              "text": "</em>",
+              "type": "html",
+            },
+            {
+              "escaped": false,
+              "raw": " is italic.",
+              "text": " is italic.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -2321,24 +2106,27 @@ exports[`Headings Alternate Syntax: Heading level 1 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 32,
-            "fontWeight": "bold",
-            "letterSpacing": 0,
-            "lineHeight": 40,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        Heading level 1
-      </Text>,
+      {
+        "id": "heading-e6141e5d-0",
+        "raw": "Heading level 1
+===============",
+        "token": {
+          "depth": 1,
+          "raw": "Heading level 1
+===============",
+          "text": "Heading level 1",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 1",
+              "text": "Heading level 1",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2397,23 +2185,27 @@ exports[`Headings Alternate Syntax: Heading level 2 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 28,
-            "fontWeight": "500",
-            "lineHeight": 36,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        Heading level 2
-      </Text>,
+      {
+        "id": "heading-8b0c3ce-0",
+        "raw": "Heading level 2
+---------------",
+        "token": {
+          "depth": 2,
+          "raw": "Heading level 2
+---------------",
+          "text": "Heading level 2",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 2",
+              "text": "Heading level 2",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2471,74 +2263,61 @@ exports[`Headings Best Practice 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Try to put a blank line before...
-          </Text>
-        </Text>
-      </View>,
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 32,
-            "fontWeight": "bold",
-            "letterSpacing": 0,
-            "lineHeight": 40,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        Heading
-      </Text>,
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            ...and after a heading.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-2edcacc2-0",
+        "raw": "Try to put a blank line before...",
+        "token": {
+          "raw": "Try to put a blank line before...",
+          "text": "Try to put a blank line before...",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Try to put a blank line before...",
+              "text": "Try to put a blank line before...",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
+      {
+        "id": "heading-4bb4640e-1",
+        "raw": "# Heading",
+        "token": {
+          "depth": 1,
+          "raw": "# Heading",
+          "text": "Heading",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading",
+              "text": "Heading",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
+      {
+        "id": "paragraph-9cd99a03-2",
+        "raw": "...and after a heading.",
+        "token": {
+          "raw": "...and after a heading.",
+          "text": "...and after a heading.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "...and after a heading.",
+              "text": "...and after a heading.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -2659,24 +2438,25 @@ exports[`Headings Heading level 1 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 32,
-            "fontWeight": "bold",
-            "letterSpacing": 0,
-            "lineHeight": 40,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        Heading level 1
-      </Text>,
+      {
+        "id": "heading-30698fc9-0",
+        "raw": "# Heading level 1",
+        "token": {
+          "depth": 1,
+          "raw": "# Heading level 1",
+          "text": "Heading level 1",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 1",
+              "text": "Heading level 1",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2735,23 +2515,25 @@ exports[`Headings Heading level 2 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 28,
-            "fontWeight": "500",
-            "lineHeight": 36,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        Heading level 2
-      </Text>,
+      {
+        "id": "heading-c0e81f29-0",
+        "raw": "## Heading level 2",
+        "token": {
+          "depth": 2,
+          "raw": "## Heading level 2",
+          "text": "Heading level 2",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 2",
+              "text": "Heading level 2",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2809,20 +2591,25 @@ exports[`Headings Heading level 3 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "color": "#333333",
-            "fontSize": 24,
-            "fontWeight": "500",
-            "lineHeight": 32,
-            "marginVertical": 4,
-          }
-        }
-      >
-        Heading level 3
-      </Text>,
+      {
+        "id": "heading-37758bab-0",
+        "raw": "### Heading level 3",
+        "token": {
+          "depth": 3,
+          "raw": "### Heading level 3",
+          "text": "Heading level 3",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 3",
+              "text": "Heading level 3",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2877,20 +2664,25 @@ exports[`Headings Heading level 4 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "color": "#333333",
-            "fontSize": 22,
-            "fontWeight": "500",
-            "lineHeight": 28,
-            "marginVertical": 4,
-          }
-        }
-      >
-        Heading level 4
-      </Text>,
+      {
+        "id": "heading-dacd5ecf-0",
+        "raw": "#### Heading level 4",
+        "token": {
+          "depth": 4,
+          "raw": "#### Heading level 4",
+          "text": "Heading level 4",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 4",
+              "text": "Heading level 4",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -2945,20 +2737,25 @@ exports[`Headings Heading level 5 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "color": "#333333",
-            "fontSize": 16,
-            "fontWeight": "500",
-            "lineHeight": 24,
-            "marginVertical": 2,
-          }
-        }
-      >
-        Heading level 5
-      </Text>,
+      {
+        "id": "heading-9b4fb78d-0",
+        "raw": "##### Heading level 5",
+        "token": {
+          "depth": 5,
+          "raw": "##### Heading level 5",
+          "text": "Heading level 5",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 5",
+              "text": "Heading level 5",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -3013,20 +2810,25 @@ exports[`Headings Heading level 6 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "color": "#333333",
-            "fontSize": 14,
-            "fontWeight": "500",
-            "lineHeight": 20,
-            "marginVertical": 2,
-          }
-        }
-      >
-        Heading level 6
-      </Text>,
+      {
+        "id": "heading-59f742ed-0",
+        "raw": "###### Heading level 6",
+        "token": {
+          "depth": 6,
+          "raw": "###### Heading level 6",
+          "text": "Heading level 6",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Heading level 6",
+              "text": "Heading level 6",
+              "type": "text",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -3081,60 +2883,39 @@ exports[`Headings Heading with text emphasis 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 28,
-            "fontWeight": "500",
-            "lineHeight": 36,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={
+      {
+        "id": "heading-b4e8fd69-0",
+        "raw": "## ~~_Heading level 2_~~",
+        "token": {
+          "depth": 2,
+          "raw": "## ~~_Heading level 2_~~",
+          "text": "~~_Heading level 2_~~",
+          "tokens": [
             {
-              "borderBottomColor": "#d0d7de",
-              "borderBottomWidth": 1,
-              "color": "#333333",
-              "fontSize": 28,
-              "fontWeight": "500",
-              "lineHeight": 36,
-              "marginVertical": 8,
-              "paddingBottom": 4,
-              "textDecorationLine": "line-through",
-              "textDecorationStyle": "solid",
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "borderBottomColor": "#d0d7de",
-                "borderBottomWidth": 1,
-                "color": "#333333",
-                "fontSize": 28,
-                "fontStyle": "italic",
-                "fontWeight": "500",
-                "lineHeight": 36,
-                "marginVertical": 8,
-                "paddingBottom": 4,
-                "textDecorationLine": "line-through",
-                "textDecorationStyle": "solid",
-              }
-            }
-          >
-            Heading level 2
-          </Text>
-        </Text>
-      </Text>,
+              "raw": "~~_Heading level 2_~~",
+              "text": "_Heading level 2_",
+              "tokens": [
+                {
+                  "raw": "_Heading level 2_",
+                  "text": "Heading level 2",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Heading level 2",
+                      "text": "Heading level 2",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "em",
+                },
+              ],
+              "type": "del",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -3229,57 +3010,44 @@ exports[`Hooks invokes hooks when rendering the Markdown component 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Hello 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={
+      {
+        "id": "paragraph-5b165365-0",
+        "raw": "Hello **_$$world$$_**",
+        "token": {
+          "raw": "Hello **_$$world$$_**",
+          "text": "Hello **_$$world$$_**",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Hello ",
+              "text": "Hello ",
+              "type": "text",
+            },
+            {
+              "raw": "**_$$world$$_**",
+              "text": "_$$world$$_",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              $$world$$
-            </Text>
-          </Text>
-        </Text>
-      </View>,
+                  "raw": "_$$world$$_",
+                  "text": "$$world$$",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "$$world$$",
+                      "text": "$$world$$",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "em",
+                },
+              ],
+              "type": "strong",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -3425,15 +3193,15 @@ exports[`Horizontal Rules Asterisks 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "marginVertical": 4,
-          }
-        }
-      />,
+      {
+        "id": "hr-b864fcf-0",
+        "raw": "***",
+        "token": {
+          "raw": "***",
+          "type": "hr",
+        },
+        "type": "hr",
+      },
     ]
   }
   getItem={[Function]}
@@ -3483,15 +3251,15 @@ exports[`Horizontal Rules Dashes 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "marginVertical": 4,
-          }
-        }
-      />,
+      {
+        "id": "hr-b863b68-0",
+        "raw": "---",
+        "token": {
+          "raw": "---",
+          "type": "hr",
+        },
+        "type": "hr",
+      },
     ]
   }
   getItem={[Function]}
@@ -3541,65 +3309,51 @@ exports[`Horizontal Rules Horizontal Rule with Paragraph 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Try to put a blank line before...
-          </Text>
-        </Text>
-      </View>,
-      <View
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "marginVertical": 4,
-          }
-        }
-      />,
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            ...and after a horizontal rule.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-2edcacc2-0",
+        "raw": "Try to put a blank line before...",
+        "token": {
+          "raw": "Try to put a blank line before...",
+          "text": "Try to put a blank line before...",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Try to put a blank line before...",
+              "text": "Try to put a blank line before...",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
+      {
+        "id": "hr-b863b68-1",
+        "raw": "---",
+        "token": {
+          "raw": "---",
+          "type": "hr",
+        },
+        "type": "hr",
+      },
+      {
+        "id": "paragraph-3d17b15b-2",
+        "raw": "...and after a horizontal rule.",
+        "token": {
+          "raw": "...and after a horizontal rule.",
+          "text": "...and after a horizontal rule.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "...and after a horizontal rule.",
+              "text": "...and after a horizontal rule.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -3711,15 +3465,15 @@ exports[`Horizontal Rules Underscores 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "marginVertical": 4,
-          }
-        }
-      />,
+      {
+        "id": "hr-69b374fa-0",
+        "raw": "_________________",
+        "token": {
+          "raw": "_________________",
+          "type": "hr",
+        },
+        "type": "hr",
+      },
     ]
   }
   getItem={[Function]}
@@ -3769,29 +3523,42 @@ exports[`Images Linking Images 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <TouchableHighlight
-          accessibilityHint="Opens in a new window"
-          accessibilityRole="link"
-          onPress={[Function]}
-        >
-          <Memo(MDImage)
-            alt="An old rock in the desert"
-            style={
-              {
-                "resizeMode": "cover",
-              }
-            }
-            uri="https://dummyimage.com/100x100/fff/aaa"
-          />
-        </TouchableHighlight>
-      </View>,
+      {
+        "id": "paragraph-873ada92-0",
+        "raw": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
+        "token": {
+          "raw": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
+          "text": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
+          "tokens": [
+            {
+              "href": "https://dummyimage.com/100x100/fff/aaa",
+              "raw": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
+              "text": "![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")",
+              "title": null,
+              "tokens": [
+                {
+                  "href": "https://dummyimage.com/100x100/fff/aaa",
+                  "raw": "![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")",
+                  "text": "An old rock in the desert",
+                  "title": "Shiprock, New Mexico by Beau Rogers",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "An old rock in the desert",
+                      "text": "An old rock in the desert",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "image",
+                },
+              ],
+              "type": "link",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -3904,23 +3671,33 @@ exports[`Images Render 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Memo(MDImage)
-          alt="The San Juan Mountains are beautiful!"
-          style={
+      {
+        "id": "paragraph-498f54fd-0",
+        "raw": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
+        "token": {
+          "raw": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
+          "text": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
+          "tokens": [
             {
-              "resizeMode": "cover",
-            }
-          }
-          uri="https://dummyimage.com/100x100/fff/aaa"
-        />
-      </View>,
+              "href": "https://dummyimage.com/100x100/fff/aaa",
+              "raw": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
+              "text": "The San Juan Mountains are beautiful!",
+              "title": "San Juan Mountains",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "The San Juan Mountains are beautiful!",
+                  "text": "The San Juan Mountains are beautiful!",
+                  "type": "text",
+                },
+              ],
+              "type": "image",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4011,23 +3788,42 @@ exports[`Images SVG Linking 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <TouchableHighlight
-          accessibilityHint="Opens in a new window"
-          accessibilityRole="link"
-          onPress={[Function]}
-        >
-          <Memo(MDSvg)
-            uri="https://www.svgrepo.com/show/513268/beer.svg"
-          />
-        </TouchableHighlight>
-      </View>,
+      {
+        "id": "paragraph-74325f1f-0",
+        "raw": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
+        "token": {
+          "raw": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
+          "text": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
+          "tokens": [
+            {
+              "href": "https://www.svgrepo.com",
+              "raw": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
+              "text": "![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")",
+              "title": null,
+              "tokens": [
+                {
+                  "href": "https://www.svgrepo.com/show/513268/beer.svg",
+                  "raw": "![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")",
+                  "text": "SVG Repo",
+                  "title": "SVG Repo",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "SVG Repo",
+                      "text": "SVG Repo",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "image",
+                },
+              ],
+              "type": "link",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4107,17 +3903,33 @@ exports[`Images SVG images 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Memo(MDSvg)
-          uri="https://www.svgrepo.com/show/513268/beer.svg"
-        />
-      </View>,
+      {
+        "id": "paragraph-d8f29fd7-0",
+        "raw": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
+        "token": {
+          "raw": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
+          "text": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
+          "tokens": [
+            {
+              "href": "https://www.svgrepo.com/show/513268/beer.svg",
+              "raw": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
+              "text": "svg",
+              "title": null,
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "svg",
+                  "text": "svg",
+                  "type": "text",
+                },
+              ],
+              "type": "image",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4175,32 +3987,29 @@ exports[`Line Breaks Trailing New Line Character 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            First line with a backslash after.
-And the next line.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-761e3989-0",
+        "raw": "First line with a backslash after.
+And the next line.",
+        "token": {
+          "raw": "First line with a backslash after.
+And the next line.",
+          "text": "First line with a backslash after.
+And the next line.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "First line with a backslash after.
+And the next line.",
+              "text": "First line with a backslash after.
+And the next line.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4267,50 +4076,38 @@ exports[`Line Breaks Trailing slash 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            First line with a backslash after.
-          </Text>
-          <Text
-            selectable={true}
-            style={{}}
-          >
-            
-
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-                  And the next line.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-ed14f495-0",
+        "raw": "First line with a backslash after.\\
+      And the next line.",
+        "token": {
+          "raw": "First line with a backslash after.\\
+      And the next line.",
+          "text": "First line with a backslash after.\\
+      And the next line.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "First line with a backslash after.",
+              "text": "First line with a backslash after.",
+              "type": "text",
+            },
+            {
+              "raw": "\\
+",
+              "type": "br",
+            },
+            {
+              "escaped": false,
+              "raw": "      And the next line.",
+              "text": "      And the next line.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4395,60 +4192,45 @@ exports[`Links Basic 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            My favorite search engine is 
-          </Text>
-          <Text
-            accessibilityHint="Opens in a new window"
-            accessibilityLabel="Link"
-            accessibilityRole="link"
-            onPress={[Function]}
-            selectable={true}
-            style={
-              {
-                "color": "#58a6ff",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            Duck Duck Go
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-df05a9a8-0",
+        "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com).",
+        "token": {
+          "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com).",
+          "text": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com).",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "My favorite search engine is ",
+              "text": "My favorite search engine is ",
+              "type": "text",
+            },
+            {
+              "href": "https://duckduckgo.com",
+              "raw": "[Duck Duck Go](https://duckduckgo.com)",
+              "text": "Duck Duck Go",
+              "title": null,
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Duck Duck Go",
+                  "text": "Duck Duck Go",
+                  "type": "text",
+                },
+              ],
+              "type": "link",
+            },
+            {
+              "escaped": false,
+              "raw": ".",
+              "text": ".",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4543,159 +4325,110 @@ exports[`Links Formatting Links 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            I love supporting the 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              accessibilityHint="Opens in a new window"
-              accessibilityLabel="Link"
-              accessibilityRole="link"
-              onPress={[Function]}
-              selectable={true}
-              style={
+      {
+        "id": "paragraph-23e1817e-0",
+        "raw": "I love supporting the **[EFF](https://eff.org)**.
+This is the *[Markdown Guide](https://www.markdownguide.org)*.
+See the section on [\`code\`](#code).",
+        "token": {
+          "raw": "I love supporting the **[EFF](https://eff.org)**.
+This is the *[Markdown Guide](https://www.markdownguide.org)*.
+See the section on [\`code\`](#code).",
+          "text": "I love supporting the **[EFF](https://eff.org)**.
+This is the *[Markdown Guide](https://www.markdownguide.org)*.
+See the section on [\`code\`](#code).",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "I love supporting the ",
+              "text": "I love supporting the ",
+              "type": "text",
+            },
+            {
+              "raw": "**[EFF](https://eff.org)**",
+              "text": "[EFF](https://eff.org)",
+              "tokens": [
                 {
-                  "color": "#58a6ff",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              EFF
-            </Text>
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-This is the 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              accessibilityHint="Opens in a new window"
-              accessibilityLabel="Link"
-              accessibilityRole="link"
-              onPress={[Function]}
-              selectable={true}
-              style={
+                  "href": "https://eff.org",
+                  "raw": "[EFF](https://eff.org)",
+                  "text": "EFF",
+                  "title": null,
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "EFF",
+                      "text": "EFF",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "link",
+                },
+              ],
+              "type": "strong",
+            },
+            {
+              "escaped": false,
+              "raw": ".
+This is the ",
+              "text": ".
+This is the ",
+              "type": "text",
+            },
+            {
+              "raw": "*[Markdown Guide](https://www.markdownguide.org)*",
+              "text": "[Markdown Guide](https://www.markdownguide.org)",
+              "tokens": [
                 {
-                  "color": "#58a6ff",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              Markdown Guide
-            </Text>
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-See the section on 
-          </Text>
-          <Text
-            accessibilityHint="Opens in a new window"
-            accessibilityLabel="Link"
-            accessibilityRole="link"
-            onPress={[Function]}
-            selectable={true}
-            style={
-              {
-                "color": "#58a6ff",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={
+                  "href": "https://www.markdownguide.org",
+                  "raw": "[Markdown Guide](https://www.markdownguide.org)",
+                  "text": "Markdown Guide",
+                  "title": null,
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Markdown Guide",
+                      "text": "Markdown Guide",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "link",
+                },
+              ],
+              "type": "em",
+            },
+            {
+              "escaped": false,
+              "raw": ".
+See the section on ",
+              "text": ".
+See the section on ",
+              "type": "text",
+            },
+            {
+              "href": "#code",
+              "raw": "[\`code\`](#code)",
+              "text": "\`code\`",
+              "title": null,
+              "tokens": [
                 {
-                  "backgroundColor": "#f6f8fa",
-                  "color": "#333333",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "300",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              code
-            </Text>
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-          </Text>
-        </Text>
-      </View>,
+                  "raw": "\`code\`",
+                  "text": "code",
+                  "type": "codespan",
+                },
+              ],
+              "type": "link",
+            },
+            {
+              "escaped": false,
+              "raw": ".",
+              "text": ".",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -4889,39 +4622,37 @@ exports[`Links Links without text, (no render) 1`] = `
 <RCTScrollView
   data={
     [
-      <Text
-        selectable={true}
-        style={
-          {
-            "borderBottomColor": "#d0d7de",
-            "borderBottomWidth": 1,
-            "color": "#333333",
-            "fontSize": 28,
-            "fontWeight": "500",
-            "lineHeight": 36,
-            "marginVertical": 8,
-            "paddingBottom": 4,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={
+      {
+        "id": "heading-83fc01f8-0",
+        "raw": "Table of Contents[](https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents)
+-------------------------------------------------------------------------------------------------------------------------------------------
+",
+        "token": {
+          "depth": 2,
+          "raw": "Table of Contents[](https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents)
+-------------------------------------------------------------------------------------------------------------------------------------------
+",
+          "text": "Table of Contents[](https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents)",
+          "tokens": [
             {
-              "borderBottomColor": "#d0d7de",
-              "borderBottomWidth": 1,
-              "color": "#333333",
-              "fontSize": 28,
-              "fontWeight": "500",
-              "lineHeight": 36,
-              "marginVertical": 8,
-              "paddingBottom": 4,
-            }
-          }
-        >
-          Table of Contents
-        </Text>
-      </Text>,
+              "escaped": false,
+              "raw": "Table of Contents",
+              "text": "Table of Contents",
+              "type": "text",
+            },
+            {
+              "href": "https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents",
+              "raw": "[](https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents)",
+              "text": "",
+              "title": null,
+              "tokens": [],
+              "type": "link",
+            },
+          ],
+          "type": "heading",
+        },
+        "type": "heading",
+      },
     ]
   }
   getItem={[Function]}
@@ -4995,60 +4726,45 @@ exports[`Links Titles 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            My favorite search engine is 
-          </Text>
-          <Text
-            accessibilityHint="Opens in a new window"
-            accessibilityLabel="The best search engine for privacy"
-            accessibilityRole="link"
-            onPress={[Function]}
-            selectable={true}
-            style={
-              {
-                "color": "#58a6ff",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            Duck Duck Go
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            .
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-f3c3b96c-0",
+        "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").",
+        "token": {
+          "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").",
+          "text": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "My favorite search engine is ",
+              "text": "My favorite search engine is ",
+              "type": "text",
+            },
+            {
+              "href": "https://duckduckgo.com",
+              "raw": "[Duck Duck Go](https://duckduckgo.com "The best search engine for privacy")",
+              "text": "Duck Duck Go",
+              "title": "The best search engine for privacy",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Duck Duck Go",
+                  "text": "Duck Duck Go",
+                  "type": "text",
+                },
+              ],
+              "type": "link",
+            },
+            {
+              "escaped": false,
+              "raw": ".",
+              "text": ".",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -5143,66 +4859,56 @@ exports[`Links URLs and Email Addresses 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            accessibilityHint="Opens in a new window"
-            accessibilityLabel="Link"
-            accessibilityRole="link"
-            onPress={[Function]}
-            selectable={true}
-            style={
-              {
-                "color": "#58a6ff",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            https://www.markdownguide.org
-          </Text>
-        </Text>
-      </View>,
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            accessibilityHint="Opens in a new window"
-            accessibilityLabel="Link"
-            accessibilityRole="link"
-            onPress={[Function]}
-            selectable={true}
-            style={
-              {
-                "color": "#58a6ff",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            fake@example.com
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-7bc7a926-0",
+        "raw": "<https://www.markdownguide.org>",
+        "token": {
+          "raw": "<https://www.markdownguide.org>",
+          "text": "<https://www.markdownguide.org>",
+          "tokens": [
+            {
+              "href": "https://www.markdownguide.org",
+              "raw": "<https://www.markdownguide.org>",
+              "text": "https://www.markdownguide.org",
+              "tokens": [
+                {
+                  "raw": "https://www.markdownguide.org",
+                  "text": "https://www.markdownguide.org",
+                  "type": "text",
+                },
+              ],
+              "type": "link",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
+      {
+        "id": "paragraph-e32df449-1",
+        "raw": "<fake@example.com>",
+        "token": {
+          "raw": "<fake@example.com>",
+          "text": "<fake@example.com>",
+          "tokens": [
+            {
+              "href": "mailto:fake@example.com",
+              "raw": "<fake@example.com>",
+              "text": "fake@example.com",
+              "tokens": [
+                {
+                  "raw": "fake@example.com",
+                  "text": "fake@example.com",
+                  "type": "text",
+                },
+              ],
+              "type": "link",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -5309,167 +5015,131 @@ exports[`Lists Elements in Lists: Blockquotes 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-e51526f4-0",
+        "raw": "- This is the first list item.
+- Here's the second list item.
+
+    > A blockquote would look great below the second list item.
+
+- And here's the third list item.",
+        "token": {
+          "items": [
+            {
+              "loose": true,
+              "raw": "- This is the first list item.
+",
+              "task": false,
+              "text": "This is the first list item.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    This is the first list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Here's the second list item.
-                  </Text>
-                </Text>
-              </View>
-              <View
-                style={
-                  {
-                    "borderLeftColor": "#d0d7de",
-                    "borderLeftWidth": 4,
-                    "opacity": 0.8,
-                    "paddingLeft": 16,
-                  }
-                }
-              >
-                <View
-                  style={
+                  "raw": "This is the first list item.",
+                  "text": "This is the first list item.",
+                  "tokens": [
                     {
-                      "paddingVertical": 8,
-                    }
-                  }
-                >
-                  <Text
-                    selectable={true}
-                    style={{}}
-                  >
-                    <Text
-                      selectable={true}
-                      style={
-                        {
-                          "color": "#333333",
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      A blockquote would look great below the second list item.
-                    </Text>
-                  </Text>
-                </View>
-              </View>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "This is the first list item.",
+                      "text": "This is the first list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "- Here's the second list item.
+
+    > A blockquote would look great below the second list item.
+
+",
+              "task": false,
+              "text": "Here's the second list item.
+
+  > A blockquote would look great below the second list item.
+",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    And here's the third list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={false}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                  "raw": "Here's the second list item.",
+                  "text": "Here's the second list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Here's the second list item.",
+                      "text": "Here's the second list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+                {
+                  "raw": "
+
+",
+                  "type": "space",
+                },
+                {
+                  "raw": "  > A blockquote would look great below the second list item.
+",
+                  "text": "A blockquote would look great below the second list item.",
+                  "tokens": [
+                    {
+                      "raw": "A blockquote would look great below the second list item.",
+                      "text": "A blockquote would look great below the second list item.",
+                      "tokens": [
+                        {
+                          "escaped": false,
+                          "raw": "A blockquote would look great below the second list item.",
+                          "text": "A blockquote would look great below the second list item.",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "blockquote",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "- And here's the third list item.",
+              "task": false,
+              "text": "And here's the third list item.",
+              "tokens": [
+                {
+                  "raw": "And here's the third list item.",
+                  "text": "And here's the third list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "And here's the third list item.",
+                      "text": "And here's the third list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": true,
+          "ordered": false,
+          "raw": "- This is the first list item.
+- Here's the second list item.
+
+    > A blockquote would look great below the second list item.
+
+- And here's the third list item.",
+          "start": "",
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -5771,162 +5441,136 @@ exports[`Lists Elements in Lists: Code Blocks 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    This is the first list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Here's the second list item.
-                  </Text>
-                </Text>
-              </View>
-              <ScrollView
-                contentContainerStyle={
-                  {
-                    "backgroundColor": "#f6f8fa",
-                    "minWidth": "100%",
-                    "padding": 16,
-                  }
-                }
-                horizontal={true}
-              >
-                <View>
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "fontStyle": "normal",
-                        "fontWeight": "400",
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                      &lt;html&gt;
-  &lt;head&gt;
-  &lt;/head&gt;
-  &lt;/html&gt;
+      {
+        "id": "list-ec19bf1-0",
+        "raw": "* This is the first list item.
+* Here's the second list item.
 
-                  </Text>
-                </View>
-              </ScrollView>
-            </View>,
-            <View
-              style={
+        <html>
+        <head>
+        </head>
+        </html>
+
+* And here's the third list item.",
+        "token": {
+          "items": [
+            {
+              "loose": true,
+              "raw": "* This is the first list item.
+",
+              "task": false,
+              "text": "This is the first list item.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    And here's the third list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={false}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                  "raw": "This is the first list item.",
+                  "text": "This is the first list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "This is the first list item.",
+                      "text": "This is the first list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "* Here's the second list item.
+
+        <html>
+        <head>
+        </head>
+        </html>
+
+",
+              "task": false,
+              "text": "Here's the second list item.
+
+      <html>
+      <head>
+      </head>
+      </html>
+",
+              "tokens": [
+                {
+                  "raw": "Here's the second list item.",
+                  "text": "Here's the second list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Here's the second list item.",
+                      "text": "Here's the second list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+                {
+                  "raw": "
+
+",
+                  "type": "space",
+                },
+                {
+                  "codeBlockStyle": "indented",
+                  "raw": "      <html>
+      <head>
+      </head>
+      </html>
+",
+                  "text": "  <html>
+  <head>
+  </head>
+  </html>
+",
+                  "type": "code",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "* And here's the third list item.",
+              "task": false,
+              "text": "And here's the third list item.",
+              "tokens": [
+                {
+                  "raw": "And here's the third list item.",
+                  "text": "And here's the third list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "And here's the third list item.",
+                      "text": "And here's the third list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": true,
+          "ordered": false,
+          "raw": "* This is the first list item.
+* Here's the second list item.
+
+        <html>
+        <head>
+        </head>
+        </html>
+
+* And here's the third list item.",
+          "start": "",
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -6225,171 +5869,132 @@ exports[`Lists Elements in Lists: Images 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-de2755f6-0",
+        "raw": "1. Open the file containing the Linux mascot.
+2. Marvel at its beauty.
+
+    ![](https://dummyimage.com/100x100/fff/aaa)
+
+3. Close the file.",
+        "token": {
+          "items": [
+            {
+              "loose": true,
+              "raw": "1. Open the file containing the Linux mascot.
+",
+              "task": false,
+              "text": "Open the file containing the Linux mascot.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Open the file containing the Linux mascot.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Marvel at its beauty.
-                  </Text>
-                </Text>
-              </View>
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Open the file containing the Linux mascot.",
+                  "text": "Open the file containing the Linux mascot.",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                     
-                  </Text>
-                </Text>
-                <Memo(MDImage)
-                  alt={null}
-                  style={
-                    {
-                      "resizeMode": "cover",
-                    }
-                  }
-                  uri="https://dummyimage.com/100x100/fff/aaa"
-                />
-              </View>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "Open the file containing the Linux mascot.",
+                      "text": "Open the file containing the Linux mascot.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "2. Marvel at its beauty.
+
+    ![](https://dummyimage.com/100x100/fff/aaa)
+
+",
+              "task": false,
+              "text": "Marvel at its beauty.
+
+ ![](https://dummyimage.com/100x100/fff/aaa)
+",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Close the file.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={true}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                  "raw": "Marvel at its beauty.",
+                  "text": "Marvel at its beauty.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Marvel at its beauty.",
+                      "text": "Marvel at its beauty.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+                {
+                  "raw": "
+
+",
+                  "type": "space",
+                },
+                {
+                  "raw": " ![](https://dummyimage.com/100x100/fff/aaa)
+",
+                  "text": " ![](https://dummyimage.com/100x100/fff/aaa)",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": " ",
+                      "text": " ",
+                      "type": "text",
+                    },
+                    {
+                      "href": "https://dummyimage.com/100x100/fff/aaa",
+                      "raw": "![](https://dummyimage.com/100x100/fff/aaa)",
+                      "text": "",
+                      "title": null,
+                      "tokens": [],
+                      "type": "image",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "3. Close the file.",
+              "task": false,
+              "text": "Close the file.",
+              "tokens": [
+                {
+                  "raw": "Close the file.",
+                  "text": "Close the file.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Close the file.",
+                      "text": "Close the file.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": true,
+          "ordered": true,
+          "raw": "1. Open the file containing the Linux mascot.
+2. Marvel at its beauty.
+
+    ![](https://dummyimage.com/100x100/fff/aaa)
+
+3. Close the file.",
+          "start": 1,
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -6728,208 +6333,181 @@ exports[`Lists Elements in Lists: Lists 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-26d99293-0",
+        "raw": "1. First item
+2. Second item
+3. Third item
+    - Indented item1
+    - Indented item2
+4. Fourth item",
+        "token": {
+          "items": [
+            {
+              "loose": false,
+              "raw": "1. First item
+",
+              "task": false,
+              "text": "First item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "First item",
+                  "text": "First item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  First item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "First item",
+                      "text": "First item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "2. Second item
+",
+              "task": false,
+              "text": "Second item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Second item",
+                  "text": "Second item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Second item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "Second item",
+                      "text": "Second item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "3. Third item
+    - Indented item1
+    - Indented item2
+",
+              "task": false,
+              "text": "Third item
+ - Indented item1
+ - Indented item2",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Third item
+",
+                  "text": "Third item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Third item
-                </Text>
-              </Text>
-              <Memo(MDList)
-                li={
-                  [
-                    <View
-                      style={
+                      "escaped": false,
+                      "raw": "Third item",
+                      "text": "Third item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+                {
+                  "items": [
+                    {
+                      "loose": false,
+                      "raw": " - Indented item1
+",
+                      "task": false,
+                      "text": "Indented item1",
+                      "tokens": [
                         {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
+                          "raw": "Indented item1",
+                          "text": "Indented item1",
+                          "tokens": [
                             {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item1
-                        </Text>
-                      </Text>
-                    </View>,
-                    <View
-                      style={
-                        {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
-                            {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item2
-                        </Text>
-                      </Text>
-                    </View>,
-                  ]
-                }
-                listStyle={{}}
-                ordered={false}
-                startIndex={1}
-                textStyle={
-                  {
-                    "color": "#333333",
-                    "flexShrink": 1,
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              />
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                              "escaped": false,
+                              "raw": "Indented item1",
+                              "text": "Indented item1",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Fourth item
-                </Text>
-              </Text>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={true}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                      "loose": false,
+                      "raw": " - Indented item2",
+                      "task": false,
+                      "text": "Indented item2",
+                      "tokens": [
+                        {
+                          "raw": "Indented item2",
+                          "text": "Indented item2",
+                          "tokens": [
+                            {
+                              "escaped": false,
+                              "raw": "Indented item2",
+                              "text": "Indented item2",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
+                  ],
+                  "loose": false,
+                  "ordered": false,
+                  "raw": " - Indented item1
+ - Indented item2",
+                  "start": "",
+                  "type": "list",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "4. Fourth item",
+              "task": false,
+              "text": "Fourth item",
+              "tokens": [
+                {
+                  "raw": "Fourth item",
+                  "text": "Fourth item",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Fourth item",
+                      "text": "Fourth item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": false,
+          "ordered": true,
+          "raw": "1. First item
+2. Second item
+3. Third item
+    - Indented item1
+    - Indented item2
+4. Fourth item",
+          "start": 1,
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -7372,156 +6950,124 @@ exports[`Lists Elements in Lists: Paragraphs 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-d6423403-0",
+        "raw": "- This is the first list item.
+- Here's the second list item.
+
+    I need to add another paragraph below the second list item.
+
+- And here's the third list item.",
+        "token": {
+          "items": [
+            {
+              "loose": true,
+              "raw": "- This is the first list item.
+",
+              "task": false,
+              "text": "This is the first list item.",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    This is the first list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-            <View
-              style={
+                  "raw": "This is the first list item.",
+                  "text": "This is the first list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "This is the first list item.",
+                      "text": "This is the first list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "- Here's the second list item.
+
+    I need to add another paragraph below the second list item.
+
+",
+              "task": false,
+              "text": "Here's the second list item.
+
+  I need to add another paragraph below the second list item.
+",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Here's the second list item.
-                  </Text>
-                </Text>
-              </View>
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                      I need to add another paragraph below the second list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-            <View
-              style={
+                  "raw": "Here's the second list item.",
+                  "text": "Here's the second list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Here's the second list item.",
+                      "text": "Here's the second list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <View
-                style={
-                  {
-                    "paddingVertical": 8,
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={{}}
-                >
-                  <Text
-                    selectable={true}
-                    style={
-                      {
-                        "color": "#333333",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    And here's the third list item.
-                  </Text>
-                </Text>
-              </View>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={false}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                  "raw": "
+
+",
+                  "type": "space",
+                },
+                {
+                  "raw": "  I need to add another paragraph below the second list item.
+",
+                  "text": "  I need to add another paragraph below the second list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "  I need to add another paragraph below the second list item.",
+                      "text": "  I need to add another paragraph below the second list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": true,
+              "raw": "- And here's the third list item.",
+              "task": false,
+              "text": "And here's the third list item.",
+              "tokens": [
+                {
+                  "raw": "And here's the third list item.",
+                  "text": "And here's the third list item.",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "And here's the third list item.",
+                      "text": "And here's the third list item.",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": true,
+          "ordered": false,
+          "raw": "- This is the first list item.
+- Here's the second list item.
+
+    I need to add another paragraph below the second list item.
+
+- And here's the third list item.",
+          "start": "",
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -7812,208 +7358,181 @@ exports[`Lists Ordered Lists 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-dbc68170-0",
+        "raw": "1. First item
+2. Second item
+3. Third item
+    1. Indented item1
+    2. Indented item2
+4. Fourth item",
+        "token": {
+          "items": [
+            {
+              "loose": false,
+              "raw": "1. First item
+",
+              "task": false,
+              "text": "First item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "First item",
+                  "text": "First item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  First item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "First item",
+                      "text": "First item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "2. Second item
+",
+              "task": false,
+              "text": "Second item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Second item",
+                  "text": "Second item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Second item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "Second item",
+                      "text": "Second item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "3. Third item
+    1. Indented item1
+    2. Indented item2
+",
+              "task": false,
+              "text": "Third item
+ 1. Indented item1
+ 2. Indented item2",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Third item
+",
+                  "text": "Third item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Third item
-                </Text>
-              </Text>
-              <Memo(MDList)
-                li={
-                  [
-                    <View
-                      style={
+                      "escaped": false,
+                      "raw": "Third item",
+                      "text": "Third item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+                {
+                  "items": [
+                    {
+                      "loose": false,
+                      "raw": " 1. Indented item1
+",
+                      "task": false,
+                      "text": "Indented item1",
+                      "tokens": [
                         {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
+                          "raw": "Indented item1",
+                          "text": "Indented item1",
+                          "tokens": [
                             {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item1
-                        </Text>
-                      </Text>
-                    </View>,
-                    <View
-                      style={
-                        {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
-                            {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item2
-                        </Text>
-                      </Text>
-                    </View>,
-                  ]
-                }
-                listStyle={{}}
-                ordered={true}
-                startIndex={1}
-                textStyle={
-                  {
-                    "color": "#333333",
-                    "flexShrink": 1,
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              />
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                              "escaped": false,
+                              "raw": "Indented item1",
+                              "text": "Indented item1",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Fourth item
-                </Text>
-              </Text>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={true}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                      "loose": false,
+                      "raw": " 2. Indented item2",
+                      "task": false,
+                      "text": "Indented item2",
+                      "tokens": [
+                        {
+                          "raw": "Indented item2",
+                          "text": "Indented item2",
+                          "tokens": [
+                            {
+                              "escaped": false,
+                              "raw": "Indented item2",
+                              "text": "Indented item2",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
+                  ],
+                  "loose": false,
+                  "ordered": true,
+                  "raw": " 1. Indented item1
+ 2. Indented item2",
+                  "start": 1,
+                  "type": "list",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "4. Fourth item",
+              "task": false,
+              "text": "Fourth item",
+              "tokens": [
+                {
+                  "raw": "Fourth item",
+                  "text": "Fourth item",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Fourth item",
+                      "text": "Fourth item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": false,
+          "ordered": true,
+          "raw": "1. First item
+2. Second item
+3. Third item
+    1. Indented item1
+    2. Indented item2
+4. Fourth item",
+          "start": 1,
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -8456,107 +7975,92 @@ exports[`Lists Ordered Lists: With Start Offset 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-a4d5d264-0",
+        "raw": "57. foo
+1. bar
+2. baz",
+        "token": {
+          "items": [
+            {
+              "loose": false,
+              "raw": "57. foo
+",
+              "task": false,
+              "text": "foo",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "foo",
+                  "text": "foo",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  foo
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "foo",
+                      "text": "foo",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "1. bar
+",
+              "task": false,
+              "text": "bar",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "bar",
+                  "text": "bar",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  bar
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "bar",
+                      "text": "bar",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "2. baz",
+              "task": false,
+              "text": "baz",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "baz",
+                  "text": "baz",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  baz
-                </Text>
-              </Text>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={true}
-        startIndex={57}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                      "escaped": false,
+                      "raw": "baz",
+                      "text": "baz",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": false,
+          "ordered": true,
+          "raw": "57. foo
+1. bar
+2. baz",
+          "start": 57,
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -8798,208 +8302,181 @@ exports[`Lists Unordered Lists 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDList)
-        li={
-          [
-            <View
-              style={
+      {
+        "id": "list-e8d8cbf7-0",
+        "raw": "- First item
+- Second item
+- Third item
+    - Indented item1
+    - Indented item2
+- Fourth item",
+        "token": {
+          "items": [
+            {
+              "loose": false,
+              "raw": "- First item
+",
+              "task": false,
+              "text": "First item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "First item",
+                  "text": "First item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  First item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "First item",
+                      "text": "First item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "- Second item
+",
+              "task": false,
+              "text": "Second item",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Second item",
+                  "text": "Second item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Second item
-                </Text>
-              </Text>
-            </View>,
-            <View
-              style={
+                      "escaped": false,
+                      "raw": "Second item",
+                      "text": "Second item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "- Third item
+    - Indented item1
+    - Indented item2
+",
+              "task": false,
+              "text": "Third item
+  - Indented item1
+  - Indented item2",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                  "raw": "Third item
+",
+                  "text": "Third item",
+                  "tokens": [
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Third item
-                </Text>
-              </Text>
-              <Memo(MDList)
-                li={
-                  [
-                    <View
-                      style={
+                      "escaped": false,
+                      "raw": "Third item",
+                      "text": "Third item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+                {
+                  "items": [
+                    {
+                      "loose": false,
+                      "raw": "  - Indented item1
+",
+                      "task": false,
+                      "text": "Indented item1",
+                      "tokens": [
                         {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
+                          "raw": "Indented item1",
+                          "text": "Indented item1",
+                          "tokens": [
                             {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item1
-                        </Text>
-                      </Text>
-                    </View>,
-                    <View
-                      style={
-                        {
-                          "color": "#333333",
-                          "flexShrink": 1,
-                          "fontSize": 16,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      <Text
-                        selectable={true}
-                        style={{}}
-                      >
-                        <Text
-                          selectable={true}
-                          style={
-                            {
-                              "color": "#333333",
-                              "fontSize": 16,
-                              "lineHeight": 24,
-                            }
-                          }
-                        >
-                          Indented item2
-                        </Text>
-                      </Text>
-                    </View>,
-                  ]
-                }
-                listStyle={{}}
-                ordered={false}
-                startIndex={1}
-                textStyle={
-                  {
-                    "color": "#333333",
-                    "flexShrink": 1,
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                  }
-                }
-              />
-            </View>,
-            <View
-              style={
-                {
-                  "color": "#333333",
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              <Text
-                selectable={true}
-                style={{}}
-              >
-                <Text
-                  selectable={true}
-                  style={
+                              "escaped": false,
+                              "raw": "Indented item1",
+                              "text": "Indented item1",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
                     {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Fourth item
-                </Text>
-              </Text>
-            </View>,
-          ]
-        }
-        listStyle={{}}
-        ordered={false}
-        startIndex={1}
-        textStyle={
-          {
-            "color": "#333333",
-            "flexShrink": 1,
-            "fontSize": 16,
-            "lineHeight": 24,
-          }
-        }
-      />,
+                      "loose": false,
+                      "raw": "  - Indented item2",
+                      "task": false,
+                      "text": "Indented item2",
+                      "tokens": [
+                        {
+                          "raw": "Indented item2",
+                          "text": "Indented item2",
+                          "tokens": [
+                            {
+                              "escaped": false,
+                              "raw": "Indented item2",
+                              "text": "Indented item2",
+                              "type": "text",
+                            },
+                          ],
+                          "type": "text",
+                        },
+                      ],
+                      "type": "list_item",
+                    },
+                  ],
+                  "loose": false,
+                  "ordered": false,
+                  "raw": "  - Indented item1
+  - Indented item2",
+                  "start": "",
+                  "type": "list",
+                },
+              ],
+              "type": "list_item",
+            },
+            {
+              "loose": false,
+              "raw": "- Fourth item",
+              "task": false,
+              "text": "Fourth item",
+              "tokens": [
+                {
+                  "raw": "Fourth item",
+                  "text": "Fourth item",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "Fourth item",
+                      "text": "Fourth item",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "text",
+                },
+              ],
+              "type": "list_item",
+            },
+          ],
+          "loose": false,
+          "ordered": false,
+          "raw": "- First item
+- Second item
+- Third item
+    - Indented item1
+    - Indented item2
+- Fourth item",
+          "start": "",
+          "type": "list",
+        },
+        "type": "list",
+      },
     ]
   }
   getItem={[Function]}
@@ -9442,56 +8919,42 @@ exports[`Paragraphs Paragraph 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            I really like using Markdown.
-          </Text>
-        </Text>
-      </View>,
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            I think I'll use it to format all of my documents from now on.
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-37e1f67-0",
+        "raw": "I really like using Markdown.",
+        "token": {
+          "raw": "I really like using Markdown.",
+          "text": "I really like using Markdown.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "I really like using Markdown.",
+              "text": "I really like using Markdown.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
+      {
+        "id": "paragraph-3c57fd7b-1",
+        "raw": "I think I'll use it to format all of my documents from now on.",
+        "token": {
+          "raw": "I think I'll use it to format all of my documents from now on.",
+          "text": "I think I'll use it to format all of my documents from now on.",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "I think I'll use it to format all of my documents from now on.",
+              "text": "I think I'll use it to format all of my documents from now on.",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -9588,46 +9051,39 @@ exports[`Paragraphs Paragraph with Image 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={
+      {
+        "id": "paragraph-1a0d2e14-0",
+        "raw": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
+        "token": {
+          "raw": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
+          "text": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
+          "tokens": [
             {
-              "color": "#333333",
-              "fontSize": 16,
-              "lineHeight": 24,
-            }
-          }
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.
-          </Text>
-        </Text>
-        <Memo(MDImage)
-          alt="Chat"
-          style={
+              "escaped": false,
+              "raw": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.",
+              "text": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.",
+              "type": "text",
+            },
             {
-              "resizeMode": "cover",
-            }
-          }
-          uri="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png"
-        />
-      </View>,
+              "href": "https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png",
+              "raw": "![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
+              "text": "Chat",
+              "title": null,
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Chat",
+                  "text": "Chat",
+                  "type": "text",
+                },
+              ],
+              "type": "image",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -9741,33 +9197,23 @@ exports[`Renderer override Custom 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            style={
-              {
-                "backgroundColor": "#f6f8fa",
-                "color": "#ff0000",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "fontWeight": "300",
-                "lineHeight": 24,
-              }
-            }
-          >
-            hello
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-d796ab67-0",
+        "raw": "\`hello\`",
+        "token": {
+          "raw": "\`hello\`",
+          "text": "\`hello\`",
+          "tokens": [
+            {
+              "raw": "\`hello\`",
+              "text": "hello",
+              "type": "codespan",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -9835,174 +9281,151 @@ exports[`Tables Alignment 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
+      {
+        "id": "table-57cf4111-0",
+        "raw": "| Syntax      | Description | Test Text     |
+| :---        |    :----:   |          ---: |
+| Header      | Title       | Here's this   |
+| Paragraph   | Text        | And more      |",
+        "token": {
+          "align": [
+            "left",
+            "center",
+            "right",
+          ],
+          "header": [
+            {
+              "align": "left",
+              "header": true,
+              "text": "Syntax",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Syntax",
+                  "text": "Syntax",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": "center",
+              "header": true,
+              "text": "Description",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Description",
+                  "text": "Description",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": "right",
+              "header": true,
+              "text": "Test Text",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Test Text",
+                  "text": "Test Text",
+                  "type": "text",
+                },
+              ],
+            },
+          ],
+          "raw": "| Syntax      | Description | Test Text     |
+| :---        |    :----:   |          ---: |
+| Header      | Title       | Here's this   |
+| Paragraph   | Text        | And more      |",
+          "rows": [
             [
-              <Text
-                selectable={true}
-                style={
+              {
+                "align": "left",
+                "header": false,
+                "text": "Header",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Syntax
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Header",
+                    "text": "Header",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "Title",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "center",
-                  }
-                }
-              >
-                Description
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Title",
+                    "text": "Title",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "right",
+                "header": false,
+                "text": "Here's this",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "right",
-                  }
-                }
-              >
-                Test Text
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Header
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  Title
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "right",
-                    }
-                  }
-                >
-                  Here's this
-                </Text>,
-              ],
+                    "escaped": false,
+                    "raw": "Here's this",
+                    "text": "Here's this",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Paragraph
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  Text
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "right",
-                    }
-                  }
-                >
-                  And more
-                </Text>,
-              ],
+              {
+                "align": "left",
+                "header": false,
+                "text": "Paragraph",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Paragraph",
+                    "text": "Paragraph",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "Text",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Text",
+                    "text": "Text",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "right",
+                "header": false,
+                "text": "And more",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "And more",
+                    "text": "And more",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-            325,
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -10383,128 +9806,111 @@ exports[`Tables Basic 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
+      {
+        "id": "table-3be802ac-0",
+        "raw": "| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |",
+        "token": {
+          "align": [
+            null,
+            null,
+          ],
+          "header": [
+            {
+              "align": null,
+              "header": true,
+              "text": "Syntax",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Syntax",
+                  "text": "Syntax",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": null,
+              "header": true,
+              "text": "Description",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Description",
+                  "text": "Description",
+                  "type": "text",
+                },
+              ],
+            },
+          ],
+          "raw": "| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |",
+          "rows": [
             [
-              <Text
-                selectable={true}
-                style={
+              {
+                "align": null,
+                "header": false,
+                "text": "Header",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Syntax
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Header",
+                    "text": "Header",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": null,
+                "header": false,
+                "text": "Title",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Description
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Header
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Title
-                </Text>,
-              ],
+                    "escaped": false,
+                    "raw": "Title",
+                    "text": "Title",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Paragraph
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Text
-                </Text>,
-              ],
+              {
+                "align": null,
+                "header": false,
+                "text": "Paragraph",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Paragraph",
+                    "text": "Paragraph",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": null,
+                "header": false,
+                "text": "Text",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Text",
+                    "text": "Text",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -10786,128 +10192,111 @@ exports[`Tables Different Cell Widths 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
+      {
+        "id": "table-549dc46c-0",
+        "raw": "| Syntax | Description |
+| --- | ----------- |
+| Header | Title |
+| Paragraph | Text |",
+        "token": {
+          "align": [
+            null,
+            null,
+          ],
+          "header": [
+            {
+              "align": null,
+              "header": true,
+              "text": "Syntax",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Syntax",
+                  "text": "Syntax",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": null,
+              "header": true,
+              "text": "Description",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Description",
+                  "text": "Description",
+                  "type": "text",
+                },
+              ],
+            },
+          ],
+          "raw": "| Syntax | Description |
+| --- | ----------- |
+| Header | Title |
+| Paragraph | Text |",
+          "rows": [
             [
-              <Text
-                selectable={true}
-                style={
+              {
+                "align": null,
+                "header": false,
+                "text": "Header",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Syntax
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Header",
+                    "text": "Header",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": null,
+                "header": false,
+                "text": "Title",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Description
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Header
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Title
-                </Text>,
-              ],
+                    "escaped": false,
+                    "raw": "Title",
+                    "text": "Title",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Paragraph
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Text
-                </Text>,
-              ],
+              {
+                "align": null,
+                "header": false,
+                "text": "Paragraph",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Paragraph",
+                    "text": "Paragraph",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": null,
+                "header": false,
+                "text": "Text",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Text",
+                    "text": "Text",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -11189,242 +10578,215 @@ exports[`Tables Emphasis, Code, Links 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
+      {
+        "id": "table-7bb9dfa7-0",
+        "raw": "| _This will also be italic_ |      _You **can** combine them_       |
+| -------------------------- | :-----------------------------------: |
+| **left foo**               |              _right foo_              |
+| \`left bar\`               |               right bar               |
+| ~~left baz~~               | right [link](https://duckduckgo.com). |",
+        "token": {
+          "align": [
+            null,
+            "center",
+          ],
+          "header": [
+            {
+              "align": null,
+              "header": true,
+              "text": "_This will also be italic_",
+              "tokens": [
+                {
+                  "raw": "_This will also be italic_",
+                  "text": "This will also be italic",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "This will also be italic",
+                      "text": "This will also be italic",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "em",
+                },
+              ],
+            },
+            {
+              "align": "center",
+              "header": true,
+              "text": "_You **can** combine them_",
+              "tokens": [
+                {
+                  "raw": "_You **can** combine them_",
+                  "text": "You **can** combine them",
+                  "tokens": [
+                    {
+                      "escaped": false,
+                      "raw": "You ",
+                      "text": "You ",
+                      "type": "text",
+                    },
+                    {
+                      "raw": "**can**",
+                      "text": "can",
+                      "tokens": [
+                        {
+                          "escaped": false,
+                          "raw": "can",
+                          "text": "can",
+                          "type": "text",
+                        },
+                      ],
+                      "type": "strong",
+                    },
+                    {
+                      "escaped": false,
+                      "raw": " combine them",
+                      "text": " combine them",
+                      "type": "text",
+                    },
+                  ],
+                  "type": "em",
+                },
+              ],
+            },
+          ],
+          "raw": "| _This will also be italic_ |      _You **can** combine them_       |
+| -------------------------- | :-----------------------------------: |
+| **left foo**               |              _right foo_              |
+| \`left bar\`               |               right bar               |
+| ~~left baz~~               | right [link](https://duckduckgo.com). |",
+          "rows": [
             [
-              <Text
-                selectable={true}
-                style={
+              {
+                "align": null,
+                "header": false,
+                "text": "**left foo**",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "fontStyle": "italic",
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                This will also be italic
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "raw": "**left foo**",
+                    "text": "left foo",
+                    "tokens": [
+                      {
+                        "escaped": false,
+                        "raw": "left foo",
+                        "text": "left foo",
+                        "type": "text",
+                      },
+                    ],
+                    "type": "strong",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "_right foo_",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "fontStyle": "italic",
-                    "lineHeight": 24,
-                    "textAlign": "center",
-                  }
-                }
-              >
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  You 
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "fontWeight": "bold",
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  can
-                </Text>
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                   combine them
-                </Text>
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontWeight": "bold",
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  left foo
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  right foo
-                </Text>,
-              ],
+                    "raw": "_right foo_",
+                    "text": "right foo",
+                    "tokens": [
+                      {
+                        "escaped": false,
+                        "raw": "right foo",
+                        "text": "right foo",
+                        "type": "text",
+                      },
+                    ],
+                    "type": "em",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "backgroundColor": "#f6f8fa",
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "fontWeight": "300",
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  left bar
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  right bar
-                </Text>,
-              ],
+              {
+                "align": null,
+                "header": false,
+                "text": "\`left bar\`",
+                "tokens": [
+                  {
+                    "raw": "\`left bar\`",
+                    "text": "left bar",
+                    "type": "codespan",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "right bar",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "right bar",
+                    "text": "right bar",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                      "textDecorationLine": "line-through",
-                      "textDecorationStyle": "solid",
-                    }
-                  }
-                >
-                  left baz
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  right 
-                </Text>,
-                <Text
-                  accessibilityHint="Opens in a new window"
-                  accessibilityLabel="Link"
-                  accessibilityRole="link"
-                  onPress={[Function]}
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#58a6ff",
-                      "fontSize": 16,
-                      "fontStyle": "italic",
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  link
-                </Text>,
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  .
-                </Text>,
-              ],
+              {
+                "align": null,
+                "header": false,
+                "text": "~~left baz~~",
+                "tokens": [
+                  {
+                    "raw": "~~left baz~~",
+                    "text": "left baz",
+                    "tokens": [
+                      {
+                        "escaped": false,
+                        "raw": "left baz",
+                        "text": "left baz",
+                        "type": "text",
+                      },
+                    ],
+                    "type": "del",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "right [link](https://duckduckgo.com).",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "right ",
+                    "text": "right ",
+                    "type": "text",
+                  },
+                  {
+                    "href": "https://duckduckgo.com",
+                    "raw": "[link](https://duckduckgo.com)",
+                    "text": "link",
+                    "title": null,
+                    "tokens": [
+                      {
+                        "escaped": false,
+                        "raw": "link",
+                        "text": "link",
+                        "type": "text",
+                      },
+                    ],
+                    "type": "link",
+                  },
+                  {
+                    "escaped": false,
+                    "raw": ".",
+                    "text": ".",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -11862,87 +11224,68 @@ exports[`Tables Images 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
-            [
-              <Text
-                selectable={true}
-                style={
-                  {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "center",
-                  }
-                }
-              >
-                Hello
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  Bingo 
-                </Text>,
-                <Memo(MDImage)
-                  alt="Tonejito"
-                  style={
-                    {
-                      "resizeMode": "cover",
-                    }
-                  }
-                  uri="https://goo.gl/1R3T6h"
-                />,
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                   This also works for me.
-                </Text>,
+      {
+        "id": "table-a43e8417-0",
+        "raw": "|                                Hello                                |
+| :-----------------------------------------------------------------: |
+| Bingo ![](https://goo.gl/1R3T6h "Tonejito") This also works for me. |",
+        "token": {
+          "align": [
+            "center",
+          ],
+          "header": [
+            {
+              "align": "center",
+              "header": true,
+              "text": "Hello",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Hello",
+                  "text": "Hello",
+                  "type": "text",
+                },
               ],
+            },
+          ],
+          "raw": "|                                Hello                                |
+| :-----------------------------------------------------------------: |
+| Bingo ![](https://goo.gl/1R3T6h "Tonejito") This also works for me. |",
+          "rows": [
+            [
+              {
+                "align": "center",
+                "header": false,
+                "text": "Bingo ![](https://goo.gl/1R3T6h "Tonejito") This also works for me.",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Bingo ",
+                    "text": "Bingo ",
+                    "type": "text",
+                  },
+                  {
+                    "href": "https://goo.gl/1R3T6h",
+                    "raw": "![](https://goo.gl/1R3T6h "Tonejito")",
+                    "text": "",
+                    "title": "Tonejito",
+                    "tokens": [],
+                    "type": "image",
+                  },
+                  {
+                    "escaped": false,
+                    "raw": " This also works for me.",
+                    "text": " This also works for me.",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -12139,174 +11482,151 @@ exports[`Tables Pipe Character 1`] = `
 <RCTScrollView
   data={
     [
-      <Memo(MDTable)
-        borderColor="#d0d7de"
-        borderWidth={1}
-        cellStyle={
-          {
-            "padding": 4,
-          }
-        }
-        header={
-          [
+      {
+        "id": "table-2ba3b01c-0",
+        "raw": "| Syntax    | Description |       Test Text |
+| :-------- | :---------: | --------------: |
+| Header    |    Title    | Here's \\| this |
+| Paragraph |    Text     |        And more |",
+        "token": {
+          "align": [
+            "left",
+            "center",
+            "right",
+          ],
+          "header": [
+            {
+              "align": "left",
+              "header": true,
+              "text": "Syntax",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Syntax",
+                  "text": "Syntax",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": "center",
+              "header": true,
+              "text": "Description",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Description",
+                  "text": "Description",
+                  "type": "text",
+                },
+              ],
+            },
+            {
+              "align": "right",
+              "header": true,
+              "text": "Test Text",
+              "tokens": [
+                {
+                  "escaped": false,
+                  "raw": "Test Text",
+                  "text": "Test Text",
+                  "type": "text",
+                },
+              ],
+            },
+          ],
+          "raw": "| Syntax    | Description |       Test Text |
+| :-------- | :---------: | --------------: |
+| Header    |    Title    | Here's \\| this |
+| Paragraph |    Text     |        And more |",
+          "rows": [
             [
-              <Text
-                selectable={true}
-                style={
+              {
+                "align": "left",
+                "header": false,
+                "text": "Header",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                  }
-                }
-              >
-                Syntax
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Header",
+                    "text": "Header",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "Title",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "center",
-                  }
-                }
-              >
-                Description
-              </Text>,
-            ],
-            [
-              <Text
-                selectable={true}
-                style={
+                    "escaped": false,
+                    "raw": "Title",
+                    "text": "Title",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "right",
+                "header": false,
+                "text": "Here's | this",
+                "tokens": [
                   {
-                    "color": "#333333",
-                    "fontSize": 16,
-                    "lineHeight": 24,
-                    "textAlign": "right",
-                  }
-                }
-              >
-                Test Text
-              </Text>,
-            ],
-          ]
-        }
-        rowStyle={
-          {
-            "flexDirection": "row",
-          }
-        }
-        rows={
-          [
-            [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Header
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  Title
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "right",
-                    }
-                  }
-                >
-                  Here's | this
-                </Text>,
-              ],
+                    "escaped": false,
+                    "raw": "Here's | this",
+                    "text": "Here's | this",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
             [
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "left",
-                    }
-                  }
-                >
-                  Paragraph
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    }
-                  }
-                >
-                  Text
-                </Text>,
-              ],
-              [
-                <Text
-                  selectable={true}
-                  style={
-                    {
-                      "color": "#333333",
-                      "fontSize": 16,
-                      "lineHeight": 24,
-                      "textAlign": "right",
-                    }
-                  }
-                >
-                  And more
-                </Text>,
-              ],
+              {
+                "align": "left",
+                "header": false,
+                "text": "Paragraph",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Paragraph",
+                    "text": "Paragraph",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "center",
+                "header": false,
+                "text": "Text",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "Text",
+                    "text": "Text",
+                    "type": "text",
+                  },
+                ],
+              },
+              {
+                "align": "right",
+                "header": false,
+                "text": "And more",
+                "tokens": [
+                  {
+                    "escaped": false,
+                    "raw": "And more",
+                    "text": "And more",
+                    "type": "text",
+                  },
+                ],
+              },
             ],
-          ]
-        }
-        widthArr={
-          [
-            325,
-            325,
-            325,
-          ]
-        }
-      />,
+          ],
+          "type": "table",
+        },
+        "type": "table",
+      },
     ]
   }
   getItem={[Function]}
@@ -12687,60 +12007,40 @@ exports[`Tokenizer Custom 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            style={
-              {
-                "backgroundColor": "#f6f8fa",
-                "color": "#ff0000",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "fontWeight": "300",
-                "lineHeight": 24,
-              }
-            }
-          >
-            latex code
-          </Text>
-        </Text>
-      </View>,
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            style={
-              {
-                "backgroundColor": "#f6f8fa",
-                "color": "#ff0000",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "fontWeight": "300",
-                "lineHeight": 24,
-              }
-            }
-          >
-            hello
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-dc79552c-0",
+        "raw": "$ latex code $",
+        "token": {
+          "raw": "$ latex code $",
+          "text": "$ latex code $",
+          "tokens": [
+            {
+              "raw": "$ latex code $",
+              "text": "latex code",
+              "type": "codespan",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
+      {
+        "id": "paragraph-d796ab67-1",
+        "raw": "\`hello\`",
+        "token": {
+          "raw": "\`hello\`",
+          "text": "\`hello\`",
+          "tokens": [
+            {
+              "raw": "\`hello\`",
+              "text": "hello",
+              "type": "codespan",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}

--- a/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Blockquotes Blockquote 1`] = `
   data={
     [
       {
-        "id": "blockquote-73ffc6f0-0",
+        "id": "blockquote-73ffc6f0",
         "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.",
         "token": {
           "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.",
@@ -106,7 +106,7 @@ exports[`Blockquotes Blockquotes with Multiple Paragraphs 1`] = `
   data={
     [
       {
-        "id": "blockquote-77de6fb9-0",
+        "id": "blockquote-77de6fb9",
         "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
 >
 > The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
@@ -257,7 +257,7 @@ exports[`Blockquotes Blockquotes with Other Elements 1`] = `
   data={
     [
       {
-        "id": "blockquote-78354748-0",
+        "id": "blockquote-78354748",
         "raw": "> #### The quarterly results look great!
 >
 > - Revenue was off the chart.
@@ -690,7 +690,7 @@ exports[`Blockquotes Nested Blockquotes 1`] = `
   data={
     [
       {
-        "id": "blockquote-730d4404-0",
+        "id": "blockquote-730d4404",
         "raw": "> Dorothy followed her through many of the beautiful rooms in her castle.
 >",
         "token": {
@@ -719,7 +719,7 @@ exports[`Blockquotes Nested Blockquotes 1`] = `
         "type": "blockquote",
       },
       {
-        "id": "blockquote-c09d6c-1",
+        "id": "blockquote-c09d6c",
         "raw": ">> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
         "token": {
           "raw": ">> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.",
@@ -880,7 +880,7 @@ exports[`Code Code Blocks (backtick) 1`] = `
   data={
     [
       {
-        "id": "code-5e6a3f25-0",
+        "id": "code-5e6a3f25",
         "raw": "\`\`\`<html>
       <head>
       </head>
@@ -972,7 +972,7 @@ exports[`Code Code Blocks (backtick), no ending backtick 1`] = `
   data={
     [
       {
-        "id": "code-552af7cf-0",
+        "id": "code-552af7cf",
         "raw": "\`\`\`<html>
       <head>
       </head>
@@ -1062,7 +1062,7 @@ exports[`Code Code Blocks 1`] = `
   data={
     [
       {
-        "id": "code-c5f1090f-0",
+        "id": "code-c5f1090f",
         "raw": "    <html>
       <head>
       </head>
@@ -1154,7 +1154,7 @@ exports[`Code Code Span 1`] = `
   data={
     [
       {
-        "id": "paragraph-23f09ebe-0",
+        "id": "paragraph-23f09ebe",
         "raw": "At the command prompt, type \`'nano'\`.",
         "token": {
           "raw": "At the command prompt, type \`'nano'\`.",
@@ -1275,7 +1275,7 @@ exports[`Emphasis Bold 1`] = `
   data={
     [
       {
-        "id": "paragraph-5111aa8a-0",
+        "id": "paragraph-5111aa8a",
         "raw": "Love **is** bold",
         "token": {
           "raw": "Love **is** bold",
@@ -1402,7 +1402,7 @@ exports[`Emphasis Bold and Italic 1`] = `
   data={
     [
       {
-        "id": "paragraph-ffa0181b-0",
+        "id": "paragraph-ffa0181b",
         "raw": "This is really ***very*** important text.",
         "token": {
           "raw": "This is really ***very*** important text.",
@@ -1549,7 +1549,7 @@ exports[`Emphasis Italic 1`] = `
   data={
     [
       {
-        "id": "paragraph-1bcd6022-0",
+        "id": "paragraph-1bcd6022",
         "raw": "A *cat* meow",
         "token": {
           "raw": "A *cat* meow",
@@ -1676,7 +1676,7 @@ exports[`Emphasis Strikethrough 1`] = `
   data={
     [
       {
-        "id": "paragraph-471a58a2-0",
+        "id": "paragraph-471a58a2",
         "raw": "A ~~cat~~ meow",
         "token": {
           "raw": "A ~~cat~~ meow",
@@ -1804,7 +1804,7 @@ exports[`Escaping Characters Render 1`] = `
   data={
     [
       {
-        "id": "paragraph-b5140f57-0",
+        "id": "paragraph-b5140f57",
         "raw": "\\* Without the backslash, this would be a bullet in an unordered list.",
         "token": {
           "raw": "\\* Without the backslash, this would be a bullet in an unordered list.",
@@ -1904,7 +1904,7 @@ exports[`HTML Render 1`] = `
   data={
     [
       {
-        "id": "paragraph-6851ed15-0",
+        "id": "paragraph-6851ed15",
         "raw": "This **word** is bold. This <em>word</em> is italic.",
         "token": {
           "raw": "This **word** is bold. This <em>word</em> is italic.",
@@ -2107,7 +2107,7 @@ exports[`Headings Alternate Syntax: Heading level 1 1`] = `
   data={
     [
       {
-        "id": "heading-e6141e5d-0",
+        "id": "heading-e6141e5d",
         "raw": "Heading level 1
 ===============",
         "token": {
@@ -2186,7 +2186,7 @@ exports[`Headings Alternate Syntax: Heading level 2 1`] = `
   data={
     [
       {
-        "id": "heading-8b0c3ce-0",
+        "id": "heading-8b0c3ce",
         "raw": "Heading level 2
 ---------------",
         "token": {
@@ -2264,7 +2264,7 @@ exports[`Headings Best Practice 1`] = `
   data={
     [
       {
-        "id": "paragraph-2edcacc2-0",
+        "id": "paragraph-2edcacc2",
         "raw": "Try to put a blank line before...",
         "token": {
           "raw": "Try to put a blank line before...",
@@ -2282,7 +2282,7 @@ exports[`Headings Best Practice 1`] = `
         "type": "paragraph",
       },
       {
-        "id": "heading-4bb4640e-1",
+        "id": "heading-4bb4640e",
         "raw": "# Heading",
         "token": {
           "depth": 1,
@@ -2301,7 +2301,7 @@ exports[`Headings Best Practice 1`] = `
         "type": "heading",
       },
       {
-        "id": "paragraph-9cd99a03-2",
+        "id": "paragraph-9cd99a03",
         "raw": "...and after a heading.",
         "token": {
           "raw": "...and after a heading.",
@@ -2439,7 +2439,7 @@ exports[`Headings Heading level 1 1`] = `
   data={
     [
       {
-        "id": "heading-30698fc9-0",
+        "id": "heading-30698fc9",
         "raw": "# Heading level 1",
         "token": {
           "depth": 1,
@@ -2516,7 +2516,7 @@ exports[`Headings Heading level 2 1`] = `
   data={
     [
       {
-        "id": "heading-c0e81f29-0",
+        "id": "heading-c0e81f29",
         "raw": "## Heading level 2",
         "token": {
           "depth": 2,
@@ -2592,7 +2592,7 @@ exports[`Headings Heading level 3 1`] = `
   data={
     [
       {
-        "id": "heading-37758bab-0",
+        "id": "heading-37758bab",
         "raw": "### Heading level 3",
         "token": {
           "depth": 3,
@@ -2665,7 +2665,7 @@ exports[`Headings Heading level 4 1`] = `
   data={
     [
       {
-        "id": "heading-dacd5ecf-0",
+        "id": "heading-dacd5ecf",
         "raw": "#### Heading level 4",
         "token": {
           "depth": 4,
@@ -2738,7 +2738,7 @@ exports[`Headings Heading level 5 1`] = `
   data={
     [
       {
-        "id": "heading-9b4fb78d-0",
+        "id": "heading-9b4fb78d",
         "raw": "##### Heading level 5",
         "token": {
           "depth": 5,
@@ -2811,7 +2811,7 @@ exports[`Headings Heading level 6 1`] = `
   data={
     [
       {
-        "id": "heading-59f742ed-0",
+        "id": "heading-59f742ed",
         "raw": "###### Heading level 6",
         "token": {
           "depth": 6,
@@ -2884,7 +2884,7 @@ exports[`Headings Heading with text emphasis 1`] = `
   data={
     [
       {
-        "id": "heading-b4e8fd69-0",
+        "id": "heading-b4e8fd69",
         "raw": "## ~~_Heading level 2_~~",
         "token": {
           "depth": 2,
@@ -3011,7 +3011,7 @@ exports[`Hooks invokes hooks when rendering the Markdown component 1`] = `
   data={
     [
       {
-        "id": "paragraph-5b165365-0",
+        "id": "paragraph-5b165365",
         "raw": "Hello **_$$world$$_**",
         "token": {
           "raw": "Hello **_$$world$$_**",
@@ -3194,7 +3194,7 @@ exports[`Horizontal Rules Asterisks 1`] = `
   data={
     [
       {
-        "id": "hr-b864fcf-0",
+        "id": "hr-b864fcf",
         "raw": "***",
         "token": {
           "raw": "***",
@@ -3252,7 +3252,7 @@ exports[`Horizontal Rules Dashes 1`] = `
   data={
     [
       {
-        "id": "hr-b863b68-0",
+        "id": "hr-b863b68",
         "raw": "---",
         "token": {
           "raw": "---",
@@ -3310,7 +3310,7 @@ exports[`Horizontal Rules Horizontal Rule with Paragraph 1`] = `
   data={
     [
       {
-        "id": "paragraph-2edcacc2-0",
+        "id": "paragraph-2edcacc2",
         "raw": "Try to put a blank line before...",
         "token": {
           "raw": "Try to put a blank line before...",
@@ -3328,7 +3328,7 @@ exports[`Horizontal Rules Horizontal Rule with Paragraph 1`] = `
         "type": "paragraph",
       },
       {
-        "id": "hr-b863b68-1",
+        "id": "hr-b863b68",
         "raw": "---",
         "token": {
           "raw": "---",
@@ -3337,7 +3337,7 @@ exports[`Horizontal Rules Horizontal Rule with Paragraph 1`] = `
         "type": "hr",
       },
       {
-        "id": "paragraph-3d17b15b-2",
+        "id": "paragraph-3d17b15b",
         "raw": "...and after a horizontal rule.",
         "token": {
           "raw": "...and after a horizontal rule.",
@@ -3466,7 +3466,7 @@ exports[`Horizontal Rules Underscores 1`] = `
   data={
     [
       {
-        "id": "hr-69b374fa-0",
+        "id": "hr-69b374fa",
         "raw": "_________________",
         "token": {
           "raw": "_________________",
@@ -3524,7 +3524,7 @@ exports[`Images Linking Images 1`] = `
   data={
     [
       {
-        "id": "paragraph-873ada92-0",
+        "id": "paragraph-873ada92",
         "raw": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
         "token": {
           "raw": "[![An old rock in the desert](https://dummyimage.com/100x100/fff/aaa "Shiprock, New Mexico by Beau Rogers")](https://dummyimage.com/100x100/fff/aaa)",
@@ -3672,7 +3672,7 @@ exports[`Images Render 1`] = `
   data={
     [
       {
-        "id": "paragraph-498f54fd-0",
+        "id": "paragraph-498f54fd",
         "raw": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
         "token": {
           "raw": "![The San Juan Mountains are beautiful!](https://dummyimage.com/100x100/fff/aaa "San Juan Mountains")",
@@ -3789,7 +3789,7 @@ exports[`Images SVG Linking 1`] = `
   data={
     [
       {
-        "id": "paragraph-74325f1f-0",
+        "id": "paragraph-74325f1f",
         "raw": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
         "token": {
           "raw": "[![SVG Repo](https://www.svgrepo.com/show/513268/beer.svg "SVG Repo")](https://www.svgrepo.com)",
@@ -3904,7 +3904,7 @@ exports[`Images SVG images 1`] = `
   data={
     [
       {
-        "id": "paragraph-d8f29fd7-0",
+        "id": "paragraph-d8f29fd7",
         "raw": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
         "token": {
           "raw": "![svg](https://www.svgrepo.com/show/513268/beer.svg)",
@@ -3988,7 +3988,7 @@ exports[`Line Breaks Trailing New Line Character 1`] = `
   data={
     [
       {
-        "id": "paragraph-761e3989-0",
+        "id": "paragraph-761e3989",
         "raw": "First line with a backslash after.
 And the next line.",
         "token": {
@@ -4077,7 +4077,7 @@ exports[`Line Breaks Trailing slash 1`] = `
   data={
     [
       {
-        "id": "paragraph-ed14f495-0",
+        "id": "paragraph-ed14f495",
         "raw": "First line with a backslash after.\\
       And the next line.",
         "token": {
@@ -4193,7 +4193,7 @@ exports[`Links Basic 1`] = `
   data={
     [
       {
-        "id": "paragraph-df05a9a8-0",
+        "id": "paragraph-df05a9a8",
         "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com).",
         "token": {
           "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com).",
@@ -4326,7 +4326,7 @@ exports[`Links Formatting Links 1`] = `
   data={
     [
       {
-        "id": "paragraph-23e1817e-0",
+        "id": "paragraph-23e1817e",
         "raw": "I love supporting the **[EFF](https://eff.org)**.
 This is the *[Markdown Guide](https://www.markdownguide.org)*.
 See the section on [\`code\`](#code).",
@@ -4623,7 +4623,7 @@ exports[`Links Links without text, (no render) 1`] = `
   data={
     [
       {
-        "id": "heading-83fc01f8-0",
+        "id": "heading-83fc01f8",
         "raw": "Table of Contents[](https://mastersoftwaretesting.com/testing-fundamentals/software-testing-101-what-is-software-testing#table-of-contents)
 -------------------------------------------------------------------------------------------------------------------------------------------
 ",
@@ -4727,7 +4727,7 @@ exports[`Links Titles 1`] = `
   data={
     [
       {
-        "id": "paragraph-f3c3b96c-0",
+        "id": "paragraph-f3c3b96c",
         "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").",
         "token": {
           "raw": "My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").",
@@ -4860,7 +4860,7 @@ exports[`Links URLs and Email Addresses 1`] = `
   data={
     [
       {
-        "id": "paragraph-7bc7a926-0",
+        "id": "paragraph-7bc7a926",
         "raw": "<https://www.markdownguide.org>",
         "token": {
           "raw": "<https://www.markdownguide.org>",
@@ -4885,7 +4885,7 @@ exports[`Links URLs and Email Addresses 1`] = `
         "type": "paragraph",
       },
       {
-        "id": "paragraph-e32df449-1",
+        "id": "paragraph-e32df449",
         "raw": "<fake@example.com>",
         "token": {
           "raw": "<fake@example.com>",
@@ -5016,7 +5016,7 @@ exports[`Lists Elements in Lists: Blockquotes 1`] = `
   data={
     [
       {
-        "id": "list-e51526f4-0",
+        "id": "list-e51526f4",
         "raw": "- This is the first list item.
 - Here's the second list item.
 
@@ -5442,7 +5442,7 @@ exports[`Lists Elements in Lists: Code Blocks 1`] = `
   data={
     [
       {
-        "id": "list-ec19bf1-0",
+        "id": "list-ec19bf1",
         "raw": "* This is the first list item.
 * Here's the second list item.
 
@@ -5870,7 +5870,7 @@ exports[`Lists Elements in Lists: Images 1`] = `
   data={
     [
       {
-        "id": "list-de2755f6-0",
+        "id": "list-de2755f6",
         "raw": "1. Open the file containing the Linux mascot.
 2. Marvel at its beauty.
 
@@ -6334,7 +6334,7 @@ exports[`Lists Elements in Lists: Lists 1`] = `
   data={
     [
       {
-        "id": "list-26d99293-0",
+        "id": "list-26d99293",
         "raw": "1. First item
 2. Second item
 3. Third item
@@ -6951,7 +6951,7 @@ exports[`Lists Elements in Lists: Paragraphs 1`] = `
   data={
     [
       {
-        "id": "list-d6423403-0",
+        "id": "list-d6423403",
         "raw": "- This is the first list item.
 - Here's the second list item.
 
@@ -7359,7 +7359,7 @@ exports[`Lists Ordered Lists 1`] = `
   data={
     [
       {
-        "id": "list-dbc68170-0",
+        "id": "list-dbc68170",
         "raw": "1. First item
 2. Second item
 3. Third item
@@ -7976,7 +7976,7 @@ exports[`Lists Ordered Lists: With Start Offset 1`] = `
   data={
     [
       {
-        "id": "list-a4d5d264-0",
+        "id": "list-a4d5d264",
         "raw": "57. foo
 1. bar
 2. baz",
@@ -8303,7 +8303,7 @@ exports[`Lists Unordered Lists 1`] = `
   data={
     [
       {
-        "id": "list-e8d8cbf7-0",
+        "id": "list-e8d8cbf7",
         "raw": "- First item
 - Second item
 - Third item
@@ -8920,7 +8920,7 @@ exports[`Paragraphs Paragraph 1`] = `
   data={
     [
       {
-        "id": "paragraph-37e1f67-0",
+        "id": "paragraph-37e1f67",
         "raw": "I really like using Markdown.",
         "token": {
           "raw": "I really like using Markdown.",
@@ -8938,7 +8938,7 @@ exports[`Paragraphs Paragraph 1`] = `
         "type": "paragraph",
       },
       {
-        "id": "paragraph-3c57fd7b-1",
+        "id": "paragraph-3c57fd7b",
         "raw": "I think I'll use it to format all of my documents from now on.",
         "token": {
           "raw": "I think I'll use it to format all of my documents from now on.",
@@ -9052,7 +9052,7 @@ exports[`Paragraphs Paragraph with Image 1`] = `
   data={
     [
       {
-        "id": "paragraph-1a0d2e14-0",
+        "id": "paragraph-1a0d2e14",
         "raw": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
         "token": {
           "raw": "Here, I'll guide you through sending desktop notifications to offline users when they have new chat messages.![Chat](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/5kq947hwxmjvlmhrbnm6.png)",
@@ -9198,7 +9198,7 @@ exports[`Renderer override Custom 1`] = `
   data={
     [
       {
-        "id": "paragraph-d796ab67-0",
+        "id": "paragraph-d796ab67",
         "raw": "\`hello\`",
         "token": {
           "raw": "\`hello\`",
@@ -9282,7 +9282,7 @@ exports[`Tables Alignment 1`] = `
   data={
     [
       {
-        "id": "table-57cf4111-0",
+        "id": "table-57cf4111",
         "raw": "| Syntax      | Description | Test Text     |
 | :---        |    :----:   |          ---: |
 | Header      | Title       | Here's this   |
@@ -9807,7 +9807,7 @@ exports[`Tables Basic 1`] = `
   data={
     [
       {
-        "id": "table-3be802ac-0",
+        "id": "table-3be802ac",
         "raw": "| Syntax      | Description |
 | ----------- | ----------- |
 | Header      | Title       |
@@ -10193,7 +10193,7 @@ exports[`Tables Different Cell Widths 1`] = `
   data={
     [
       {
-        "id": "table-549dc46c-0",
+        "id": "table-549dc46c",
         "raw": "| Syntax | Description |
 | --- | ----------- |
 | Header | Title |
@@ -10579,7 +10579,7 @@ exports[`Tables Emphasis, Code, Links 1`] = `
   data={
     [
       {
-        "id": "table-7bb9dfa7-0",
+        "id": "table-7bb9dfa7",
         "raw": "| _This will also be italic_ |      _You **can** combine them_       |
 | -------------------------- | :-----------------------------------: |
 | **left foo**               |              _right foo_              |
@@ -11225,7 +11225,7 @@ exports[`Tables Images 1`] = `
   data={
     [
       {
-        "id": "table-a43e8417-0",
+        "id": "table-a43e8417",
         "raw": "|                                Hello                                |
 | :-----------------------------------------------------------------: |
 | Bingo ![](https://goo.gl/1R3T6h "Tonejito") This also works for me. |",
@@ -11483,7 +11483,7 @@ exports[`Tables Pipe Character 1`] = `
   data={
     [
       {
-        "id": "table-2ba3b01c-0",
+        "id": "table-2ba3b01c",
         "raw": "| Syntax    | Description |       Test Text |
 | :-------- | :---------: | --------------: |
 | Header    |    Title    | Here's \\| this |
@@ -12008,7 +12008,7 @@ exports[`Tokenizer Custom 1`] = `
   data={
     [
       {
-        "id": "paragraph-dc79552c-0",
+        "id": "paragraph-dc79552c",
         "raw": "$ latex code $",
         "token": {
           "raw": "$ latex code $",
@@ -12025,7 +12025,7 @@ exports[`Tokenizer Custom 1`] = `
         "type": "paragraph",
       },
       {
-        "id": "paragraph-d796ab67-1",
+        "id": "paragraph-d796ab67",
         "raw": "\`hello\`",
         "token": {
           "raw": "\`hello\`",

--- a/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
@@ -1514,33 +1514,21 @@ exports[`code and codespan styles #873 code block uses codeText instead of em (n
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-              }
-            }
-          >
-            code
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-75db83e8-0",
+        "raw": "\`\`\`
+code
+\`\`\`",
+        "token": {
+          "lang": "",
+          "raw": "\`\`\`
+code
+\`\`\`",
+          "text": "code",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1610,34 +1598,21 @@ exports[`code and codespan styles #873 code block uses codeText style 1`] = `
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontFamily": "Menlo",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-              }
-            }
-          >
-            hello
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-9b88f5a7-0",
+        "raw": "\`\`\`
+hello
+\`\`\`",
+        "token": {
+          "lang": "",
+          "raw": "\`\`\`
+hello
+\`\`\`",
+          "text": "hello",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1708,34 +1683,21 @@ exports[`code and codespan styles #873 code block with all TextStyle props via c
 <RCTScrollView
   data={
     [
-      <ScrollView
-        contentContainerStyle={
-          {
-            "backgroundColor": "#f6f8fa",
-            "minWidth": "100%",
-            "padding": 16,
-          }
-        }
-        horizontal={true}
-      >
-        <View>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#ff0000",
-                "fontFamily": "Menlo",
-                "fontSize": 14,
-                "fontStyle": "normal",
-                "fontWeight": "700",
-                "lineHeight": 24,
-              }
-            }
-          >
-            code
-          </Text>
-        </View>
-      </ScrollView>,
+      {
+        "id": "code-75db83e8-0",
+        "raw": "\`\`\`
+code
+\`\`\`",
+        "token": {
+          "lang": "",
+          "raw": "\`\`\`
+code
+\`\`\`",
+          "text": "code",
+          "type": "code",
+        },
+        "type": "code",
+      },
     ]
   }
   getItem={[Function]}
@@ -1806,76 +1768,42 @@ exports[`code and codespan styles #873 codespan preserves style inside em 1`] = 
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontFamily": "Helvetica-Oblique",
-                "fontSize": 16,
-                "fontStyle": "italic",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={
+      {
+        "id": "paragraph-5e1331c0-0",
+        "raw": "*some \`code\` inside*",
+        "token": {
+          "raw": "*some \`code\` inside*",
+          "text": "*some \`code\` inside*",
+          "tokens": [
+            {
+              "raw": "*some \`code\` inside*",
+              "text": "some \`code\` inside",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontFamily": "Helvetica-Oblique",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              some 
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "escaped": false,
+                  "raw": "some ",
+                  "text": "some ",
+                  "type": "text",
+                },
                 {
-                  "backgroundColor": "#f6f8fa",
-                  "color": "#333333",
-                  "fontFamily": "Menlo",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "300",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              code
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "raw": "\`code\`",
+                  "text": "code",
+                  "type": "codespan",
+                },
                 {
-                  "color": "#333333",
-                  "fontFamily": "Helvetica-Oblique",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "lineHeight": 24,
-                }
-              }
-            >
-               inside
-            </Text>
-          </Text>
-        </Text>
-      </View>,
+                  "escaped": false,
+                  "raw": " inside",
+                  "text": " inside",
+                  "type": "text",
+                },
+              ],
+              "type": "em",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -1986,76 +1914,42 @@ exports[`code and codespan styles #873 codespan preserves style inside strong 1`
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontFamily": "Helvetica-Bold",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "lineHeight": 24,
-              }
-            }
-          >
-            <Text
-              selectable={true}
-              style={
+      {
+        "id": "paragraph-99f917a0-0",
+        "raw": "**some \`code\` inside**",
+        "token": {
+          "raw": "**some \`code\` inside**",
+          "text": "**some \`code\` inside**",
+          "tokens": [
+            {
+              "raw": "**some \`code\` inside**",
+              "text": "some \`code\` inside",
+              "tokens": [
                 {
-                  "color": "#333333",
-                  "fontFamily": "Helvetica-Bold",
-                  "fontSize": 16,
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              some 
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "escaped": false,
+                  "raw": "some ",
+                  "text": "some ",
+                  "type": "text",
+                },
                 {
-                  "backgroundColor": "#f6f8fa",
-                  "color": "#333333",
-                  "fontFamily": "Menlo",
-                  "fontSize": 16,
-                  "fontStyle": "italic",
-                  "fontWeight": "300",
-                  "lineHeight": 24,
-                }
-              }
-            >
-              code
-            </Text>
-            <Text
-              selectable={true}
-              style={
+                  "raw": "\`code\`",
+                  "text": "code",
+                  "type": "codespan",
+                },
                 {
-                  "color": "#333333",
-                  "fontFamily": "Helvetica-Bold",
-                  "fontSize": 16,
-                  "fontWeight": "bold",
-                  "lineHeight": 24,
-                }
-              }
-            >
-               inside
-            </Text>
-          </Text>
-        </Text>
-      </View>,
+                  "escaped": false,
+                  "raw": " inside",
+                  "text": " inside",
+                  "type": "text",
+                },
+              ],
+              "type": "strong",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}
@@ -2166,59 +2060,35 @@ exports[`code and codespan styles #873 codespan with all TextStyle props 1`] = `
 <RCTScrollView
   data={
     [
-      <View
-        style={
-          {
-            "paddingVertical": 8,
-          }
-        }
-      >
-        <Text
-          selectable={true}
-          style={{}}
-        >
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Use 
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "backgroundColor": "#f6f8fa",
-                "color": "#ff0000",
-                "fontFamily": "Menlo",
-                "fontSize": 14,
-                "fontStyle": "italic",
-                "fontWeight": "700",
-                "lineHeight": 24,
-              }
-            }
-          >
-            code
-          </Text>
-          <Text
-            selectable={true}
-            style={
-              {
-                "color": "#333333",
-                "fontSize": 16,
-                "lineHeight": 24,
-              }
-            }
-          >
-             here
-          </Text>
-        </Text>
-      </View>,
+      {
+        "id": "paragraph-8631daf1-0",
+        "raw": "Use \`code\` here",
+        "token": {
+          "raw": "Use \`code\` here",
+          "text": "Use \`code\` here",
+          "tokens": [
+            {
+              "escaped": false,
+              "raw": "Use ",
+              "text": "Use ",
+              "type": "text",
+            },
+            {
+              "raw": "\`code\`",
+              "text": "code",
+              "type": "codespan",
+            },
+            {
+              "escaped": false,
+              "raw": " here",
+              "text": " here",
+              "type": "text",
+            },
+          ],
+          "type": "paragraph",
+        },
+        "type": "paragraph",
+      },
     ]
   }
   getItem={[Function]}

--- a/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Renderer.spec.tsx.snap
@@ -1515,7 +1515,7 @@ exports[`code and codespan styles #873 code block uses codeText instead of em (n
   data={
     [
       {
-        "id": "code-75db83e8-0",
+        "id": "code-75db83e8",
         "raw": "\`\`\`
 code
 \`\`\`",
@@ -1599,7 +1599,7 @@ exports[`code and codespan styles #873 code block uses codeText style 1`] = `
   data={
     [
       {
-        "id": "code-9b88f5a7-0",
+        "id": "code-9b88f5a7",
         "raw": "\`\`\`
 hello
 \`\`\`",
@@ -1684,7 +1684,7 @@ exports[`code and codespan styles #873 code block with all TextStyle props via c
   data={
     [
       {
-        "id": "code-75db83e8-0",
+        "id": "code-75db83e8",
         "raw": "\`\`\`
 code
 \`\`\`",
@@ -1769,7 +1769,7 @@ exports[`code and codespan styles #873 codespan preserves style inside em 1`] = 
   data={
     [
       {
-        "id": "paragraph-5e1331c0-0",
+        "id": "paragraph-5e1331c0",
         "raw": "*some \`code\` inside*",
         "token": {
           "raw": "*some \`code\` inside*",
@@ -1915,7 +1915,7 @@ exports[`code and codespan styles #873 codespan preserves style inside strong 1`
   data={
     [
       {
-        "id": "paragraph-99f917a0-0",
+        "id": "paragraph-99f917a0",
         "raw": "**some \`code\` inside**",
         "token": {
           "raw": "**some \`code\` inside**",
@@ -2061,7 +2061,7 @@ exports[`code and codespan styles #873 codespan with all TextStyle props 1`] = `
   data={
     [
       {
-        "id": "paragraph-8631daf1-0",
+        "id": "paragraph-8631daf1",
         "raw": "Use \`code\` here",
         "token": {
           "raw": "Use \`code\` here",

--- a/src/lib/blockUtils.ts
+++ b/src/lib/blockUtils.ts
@@ -1,0 +1,87 @@
+import type { Token } from "marked";
+
+/**
+ * Simple deterministic hash for block id generation.
+ * Uses DJB2-like algorithm, returns hex string.
+ */
+export function hashString(str: string): string {
+	let hash = 5381;
+	for (let i = 0; i < str.length; i++) {
+		hash = (hash * 33) ^ str.charCodeAt(i);
+	}
+	return (hash >>> 0).toString(16);
+}
+
+type TokenRecord = Token & Record<string, unknown>;
+
+/**
+ * Block-token fields that affect rendered output in addition to `raw`.
+ * Comparing `raw` + `type` alone is not enough: e.g. a reference definition
+ * (`[f]: /url`) elsewhere in the document can change a link with identical
+ * `raw`, and custom tokenizers/hooks can return the same `raw` with
+ * different parsed fields.
+ */
+function fingerprintFields(token: Token): string {
+	const record = token as TokenRecord;
+	return JSON.stringify({
+		depth: record.depth ?? null,
+		lang: record.lang ?? null,
+		ordered: record.ordered ?? null,
+		start: record.start ?? null,
+		href: record.href ?? null,
+		title: record.title ?? null,
+		checked: record.checked ?? null,
+		task: record.task ?? null,
+		loose: record.loose ?? null,
+		align: record.align ?? null,
+	});
+}
+
+/**
+ * Value comparison for block tokens. Token objects are recreated on every
+ * `lexer()` call, so identity comparison never matches across renders.
+ */
+export function isSameBlockToken(a: Token, b: Token): boolean {
+	if (a.type !== b.type) {
+		return false;
+	}
+	const aRaw = (a as { raw?: string }).raw ?? "";
+	const bRaw = (b as { raw?: string }).raw ?? "";
+	if (aRaw !== bRaw) {
+		return false;
+	}
+	return fingerprintFields(a) === fingerprintFields(b);
+}
+
+export function getBlockRaw(token: Token, index: number): string {
+	return (token as { raw?: string }).raw ?? `${token.type}-${index}`;
+}
+
+/**
+ * Deterministic content-derived ids for a token list.
+ *
+ * Ids intentionally do NOT contain the token index: an index suffix would
+ * invalidate every downstream key on prepend/insert (see #451). Duplicate
+ * blocks with identical content are disambiguated with an occurrence counter
+ * (`base`, `base-1`, …), which keeps ids of surviving blocks stable when
+ * blocks are appended, prepended, inserted, or removed.
+ */
+export function assignBlockIds(tokens: Token[]): string[] {
+	const occurrences = new Map<string, number>();
+	const used = new Set<string>();
+	return tokens.map((token) => {
+		const raw = getBlockRaw(token, 0);
+		const base = `${token.type}-${hashString(raw)}`;
+		let count = occurrences.get(base) ?? 0;
+		let id = count === 0 ? base : `${base}-${count}`;
+		// Fallback for the (unlikely) case of distinct raws hashing to the
+		// same base id: bump the suffix until the id is unique in this list.
+		while (used.has(id)) {
+			count += 1;
+			id = `${base}-${count}`;
+		}
+		occurrences.set(base, count + 1);
+		used.add(id);
+		return id;
+	});
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Hooks, Tokenizer } from "marked";
+import type { Hooks, Token, Tokenizer } from "marked";
 import type { ReactNode } from "react";
 import type {
 	FlatListProps,
@@ -14,12 +14,19 @@ export interface ParserOptions {
 	renderer: RendererInterface;
 }
 
+export type MarkdownBlock = {
+	id: string;
+	token: Token;
+	raw: string;
+	type: string;
+};
+
 export interface MarkdownProps extends Partial<ParserOptions> {
 	value: string;
 	flatListProps?: Omit<
-		FlatListProps<ReactNode>,
+		FlatListProps<MarkdownBlock>,
 		"data" | "renderItem" | "horizontal"
-	>;
+	> | null;
 	theme?: UserTheme;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,10 +23,16 @@ export type MarkdownBlock = {
 
 export interface MarkdownProps extends Partial<ParserOptions> {
 	value: string;
-	flatListProps?: Omit<
-		FlatListProps<MarkdownBlock>,
-		"data" | "renderItem" | "horizontal"
-	> | null;
+	/**
+	 * Props for customizing the underlying FlatList. `MarkdownBlock` is the
+	 * current item type; `ReactNode` remains accepted for backward
+	 * compatibility with v8 and earlier. Pass `null` to disable
+	 * virtualization and render with `ScrollView` (useful for small docs).
+	 */
+	flatListProps?:
+		| Omit<FlatListProps<MarkdownBlock>, "data" | "renderItem" | "horizontal">
+		| Omit<FlatListProps<ReactNode>, "data" | "renderItem" | "horizontal">
+		| null;
 	theme?: UserTheme;
 	tokenizer?: Tokenizer;
 	hooks?: Hooks;


### PR DESCRIPTION
Fixes #451

### Root cause
Markdown used data=ReactNode[] + index keys (src/lib/Markdown.tsx:30) causing every value change to recreate all identities and FlatList to re-render all rows. Unstable styles/renderer and global slugger counter amplified.

### Changes
- **MarkdownBlock** (src/lib/types.ts:17, src/hooks/useMarkdownBlocks.ts:10) content-hash ids, stable blocks, space-filtered lexer
- **MarkdownBlock memo** (src/lib/MarkdownBlock.tsx:24) raw/type comparator, only changed blocks re-parse
- **FlatList refactor** (src/lib/Markdown.tsx:31,44,51) keyExtractor=item.id, ScrollView fallback when flatListProps=null
- **useMarkdown cache** (src/hooks/useMarkdown.ts:84,125) prefix & per-index reuse
- **Renderer** 
resetKeys() (src/lib/Renderer.tsx:13), **useMarkdownWithComponents** stable ids (src/hooks/useMarkdownWithComponents.tsx:39)
- **Docs/exports** (README.md:48,60, src/index.ts:12)
- Snapshots updated (64), new regression tests src/lib/__tests__/FlatListRerender.spec.tsx:6

### Verification
- yarn typescript pass
- yarn lint pass (8 infos only)
- yarn test --collectCoverage --silent 156/156 pass
- yarn build 24 files
- yarn reassure --silent ~7.5ms no redundant updates

BREAKING CHANGE: flatListProps generic is FlatListProps<MarkdownBlock>|null; snapshots change; callers should memoize styles/theme/renderer.