### PR TITLE
fix: pass image alt text to SVG images for accessibility

### DIFF
--- a/docs/docs/guide/examples.md
+++ b/docs/docs/guide/examples.md
@@ -19,6 +19,8 @@ Links use `onLinkPress` (`src/utils/handlers.ts`) — override via renderer `lin
 
 `.svg` URIs auto-render via `MDSvg` (`src/components/MDSvg.tsx`), others via `MDImage` (`src/components/MDImage.tsx`).
 
+Both use the markdown alt text — falling back to the title — as their `accessibilityLabel`.
+
 ### Tables
 
 Rendered with `react-native-reanimated-table` (`src/components/MDTable.tsx`) — provide `table` / `tableRow` / `tableCell` styles.

--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -131,7 +131,7 @@ class Renderer implements RendererInterface {
 	): ReactNode {
 		const key = this.getKey();
 		if (uri.endsWith(".svg")) {
-			return <MDSvg uri={uri} key={key} />;
+			return <MDSvg uri={uri} key={key} alt={alt || title} />;
 		}
 		return <MDImage key={key} uri={uri} alt={alt || title} style={style} />;
 	}

--- a/src/lib/__tests__/Renderer.spec.tsx
+++ b/src/lib/__tests__/Renderer.spec.tsx
@@ -16,6 +16,7 @@ jest.mock("react-native/Libraries/Linking/Linking", () => ({
 }));
 
 const renderer = new Renderer();
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="64px" height="64px" viewBox="0 0 64 64"><path d="M0 0h64v64H0z"/></svg>`;
 const userStyles: MarkedStyles = {
 	text: {
 		fontSize: 24,
@@ -195,6 +196,21 @@ describe("Renderer", () => {
 				});
 			});
 			describe("getImageNode", () => {
+				const originalFetch = global.fetch;
+
+				const mockSvgFetch = () => {
+					global.fetch = jest.fn(() =>
+						Promise.resolve({
+							status: 200,
+							text: () => Promise.resolve(SVG),
+						} as Response),
+					);
+				};
+
+				afterEach(() => {
+					global.fetch = originalFetch;
+				});
+
 				it("returns a Image", async () => {
 					const ImageNode = renderer.image(
 						"https://picsum.photos/100/100",
@@ -204,6 +220,30 @@ describe("Renderer", () => {
 						const tree = render(ImageNode as ReactElement).toJSON();
 						expect(tree).toMatchSnapshot();
 					});
+				});
+
+				it("returns a SVG with the alt text as accessibility label", async () => {
+					mockSvgFetch();
+					const ImageNode = renderer.image(
+						"https://example.com/logo.svg",
+						"Logo",
+					);
+					render(ImageNode as ReactElement);
+					const Svg = await screen.findByTestId("react-native-marked-md-svg");
+					expect(Svg.props.accessibilityLabel).toBe("Logo");
+				});
+
+				it("returns a SVG with the title as accessibility label when alt is absent", async () => {
+					mockSvgFetch();
+					const ImageNode = renderer.image(
+						"https://example.com/logo.svg",
+						undefined,
+						undefined,
+						"Logo title",
+					);
+					render(ImageNode as ReactElement);
+					const Svg = await screen.findByTestId("react-native-marked-md-svg");
+					expect(Svg.props.accessibilityLabel).toBe("Logo title");
 				});
 			});
 			describe("getListNode", () => {

--- a/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
+++ b/src/lib/__tests__/__snapshots__/Markdown.spec.tsx.snap
@@ -4024,6 +4024,7 @@ exports[`Images SVG Linking 1`] = `
           onPress={[Function]}
         >
           <Memo(MDSvg)
+            alt="SVG Repo"
             uri="https://www.svgrepo.com/show/513268/beer.svg"
           />
         </TouchableHighlight>
@@ -4115,6 +4116,7 @@ exports[`Images SVG images 1`] = `
         }
       >
         <Memo(MDSvg)
+          alt="svg"
           uri="https://www.svgrepo.com/show/513268/beer.svg"
         />
       </View>,


### PR DESCRIPTION
As a screen reader user, I should hear the alt text of an SVG image. Raster images already do this. The markdown `![Company logo](logo.svg)` must announce "Company logo". It must not announce only the word "image". This must also work when a link contains the image.

In this PR we send the alt text to `MDSvg`:

- `Renderer.image()` now gives `alt={alt || title}` to `MDSvg`. The `MDImage` branch below it does the same.
- `MDSvg` already accepts this prop, and sets `aria-label` and `accessibilityLabel`. No code gave the prop a value. Each `.svg` URI used the default label `"image"`.
- `Renderer.linkImage()` calls `image()`. Linked SVGs get the same correction.
- We add two tests next to the image test. One test checks the alt text. The other test checks the fallback to `title`.
- Both tests replace `fetch` with a mock. `MDSvg` then loads the file and shows `SvgFromXml`. Without the mock, the component stops in the error state, and the element with the label does not appear. This is why the old SVG snapshots show an empty `View`.
- We ran the two tests against the old code, and both tests failed. A snapshot test alone does not find an incorrect label.
- Two SVG snapshots in `Markdown.spec.tsx.snap` get the new `alt` prop. No other snapshot changes.
- We record the behavior in the "Images & SVG" section of the documents. The text covers both components, because the raster case also had no record.

We believe it is better to use the existing prop than to change the default label of `MDSvg`. This keeps the order of alt and title in one place, and makes the two image paths the same.