### PR TITLE
fix: detect .svg uris with a query, fragment or upper case extension

### DIFF
--- a/src/lib/Renderer.tsx
+++ b/src/lib/Renderer.tsx
@@ -130,7 +130,7 @@ class Renderer implements RendererInterface {
 		title?: string,
 	): ReactNode {
 		const key = this.getKey();
-		if (uri.endsWith(".svg")) {
+		if (/\.svg$/i.test(uri.replace(/[?#].*/, ""))) {
 			return <MDSvg uri={uri} key={key} alt={alt || title} />;
 		}
 		return <MDImage key={key} uri={uri} alt={alt || title} style={style} />;

--- a/src/lib/__tests__/Renderer.spec.tsx
+++ b/src/lib/__tests__/Renderer.spec.tsx
@@ -245,6 +245,30 @@ describe("Renderer", () => {
 					const Svg = await screen.findByTestId("react-native-marked-md-svg");
 					expect(Svg.props.accessibilityLabel).toBe("Logo title");
 				});
+
+				it("returns a SVG for a uri with a query string", async () => {
+					mockSvgFetch();
+					const ImageNode = renderer.image(
+						"https://example.com/logo.svg?v=1",
+						"Logo",
+					);
+					render(ImageNode as ReactElement);
+					expect(
+						await screen.findByTestId("react-native-marked-md-svg"),
+					).toBeTruthy();
+				});
+
+				it("returns a SVG for a uri with an upper case extension and a fragment", async () => {
+					mockSvgFetch();
+					const ImageNode = renderer.image(
+						"https://example.com/LOGO.SVG#top",
+						"Logo",
+					);
+					render(ImageNode as ReactElement);
+					expect(
+						await screen.findByTestId("react-native-marked-md-svg"),
+					).toBeTruthy();
+				});
 			});
 			describe("getListNode", () => {
 				it("returns Ordered List", () => {


### PR DESCRIPTION
As a user, I should see an SVG image when its address has a query string or a fragment. Many SVG assets come from a CDN. These addresses often hold a signature or a cache-busting parameter, for example `logo.svg?v=1`. Today these images are blank.

In this PR we correct the test that finds an SVG address:

- `Renderer.image()` tested `uri.endsWith(".svg")`. An address with a query string or a fragment failed this test. The address then went to `MDImage`. `MDImage` cannot draw an SVG file, and the image was blank.
- The new test removes the query string and the fragment first. It then compares the extension, and it ignores the letter case. The addresses `logo.svg?v=1`, `LOGO.SVG` and `logo.svg#top` now go to `MDSvg`.
- We add two tests next to the alt text tests. One test uses `https://example.com/logo.svg?v=1`. The other test uses `https://example.com/LOGO.SVG#top`. Both tests use the existing `fetch` mock, and both tests check that `MDSvg` renders.
- No snapshot changes. The SVG examples in `Markdown.spec.tsx` use a plain `.svg` address.

The predicate is `/\.svg$/i.test(uri.split(/[?#]/, 1)[0] ?? "")`. The repository sets `noUncheckedIndexedAccess`, so the index gives `string | undefined`. The `?? ""` gives `RegExp.test()` a `string`.

`Renderer.image()` is the only place that finds an SVG address, so one change is sufficient.

The new tests use the `fetch` mock that #1089 added.